### PR TITLE
Converted GitHub Repo Links to Relative Paths in .md Files

### DIFF
--- a/For_Makers/Board_Fixes.md
+++ b/For_Makers/Board_Fixes.md
@@ -8,14 +8,14 @@ Please ask in the [PhobGCC Discord Server](https://discord.gg/yrpUu7mgzm) if you
 
 Bridge the third and fourth pins on the top left of the Teensy 3.2/Teensy 4.0 (as seen below) and flash the proper Diode_Short version of the firmware.
 
-![Full Duplex Picture](For_Makers/BoardFixPics/full_duplex.jpg)
+![Full Duplex Picture](../For_Makers/BoardFixPics/full_duplex.jpg)
 
 ## L-stick Hall Sensor Joints - PhobGCC v1.X
 
 Due to the reversed orientation of the left stickbox on PhobGCC v1.Xs, the left trigger guard applies significant pressure to the hall effect sensor joints.
 This can deform the solder joints if leaded solder, which is soft, was used.
 
-The way to do them right is to cut the pins flush and reflow them per [the build guide](For_Makers/Build_Guide_1.2.md#bending-and-soldering-hall-sensors).
+The way to do them right is to cut the pins flush and reflow them per [the build guide](../For_Makers/Build_Guide_1.2.md#bending-and-soldering-hall-sensors).
 
 There are 3 other fixes that resolve the issue.
 
@@ -23,13 +23,13 @@ Temporarily - unscrew the shell screws by 3/4s of a turn.
 
 Unscrew the following screws 3/4s of a turn so that it takes off the pressure on the hall sensor joints.
 
-![Shell Screws](For_Makers/BoardFixPics/screws_2.jpg)
+![Shell Screws](../For_Makers/BoardFixPics/screws_2.jpg)
 
 Filing - File down the trigger guard at the circled points.
 
 Take out the two black screws holding it in place and remove the trigger guard. Proceed to file down the left trigger guard in the circled locations below to ensure that the joints are not being stressed.
 
-![Trimmed TG HES](For_Makers/BoardFixPics/hes_tg.jpg)
+![Trimmed TG HES](../For_Makers/BoardFixPics/hes_tg.jpg)
 
 
 3D Print - Either 3D print yourself or order the 3D printed bracket from a service such as JLC and swap it out.
@@ -41,7 +41,7 @@ Take out the two black screws holding it in place and remove the trigger guard. 
 As a result of the hall effect sensor placement, the analog stick is positioned upside down. This causes the notch in the skirt of the analog stick to not line up with the solder joint of the analog slider.
 There are 3 fixes that resolve the issue.
 
-![Trigger Joint](For_Makers/BoardFixPics/trigger_joint.jpg)
+![Trigger Joint](../For_Makers/BoardFixPics/trigger_joint.jpg)
 
 During Assembly - Trim the pin flush with the hole and only add a little solder so that the solder wets into the hole. This should result in a flat board on top where it does not interfere with the analog stick.
 
@@ -56,9 +56,9 @@ There are 3 fixes that resolve the issue:
 
 Filing - File down the trigger guard at the bottom of the left screw post so that it is flush with the hole as shown below. You only need to remove 0.25mm of material.
 
-![Trimmed TG JST](For_Makers/BoardFixPics/jst_tg2.jpg)
+![Trimmed TG JST](../For_Makers/BoardFixPics/jst_tg2.jpg)
 
-![INVENTOR EXAMPLE JST TG](For_Makers/BoardFixPics/jst_tg.png)
+![INVENTOR EXAMPLE JST TG](../For_Makers/BoardFixPics/jst_tg.png)
 
 3D Print - Either 3D print yourself or order the 3D printed bracket from a service such as JLC and swap it out.
 

--- a/For_Makers/Board_Fixes.md
+++ b/For_Makers/Board_Fixes.md
@@ -8,14 +8,14 @@ Please ask in the [PhobGCC Discord Server](https://discord.gg/yrpUu7mgzm) if you
 
 Bridge the third and fourth pins on the top left of the Teensy 3.2/Teensy 4.0 (as seen below) and flash the proper Diode_Short version of the firmware.
 
-![Full Duplex Picture](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BoardFixPics/full_duplex.jpg?raw=true)
+![Full Duplex Picture](For_Makers/BoardFixPics/full_duplex.jpg?raw=true)
 
 ## L-stick Hall Sensor Joints - PhobGCC v1.X
 
 Due to the reversed orientation of the left stickbox on PhobGCC v1.Xs, the left trigger guard applies significant pressure to the hall effect sensor joints.
 This can deform the solder joints if leaded solder, which is soft, was used.
 
-The way to do them right is to cut the pins flush and reflow them per [the build guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Build_Guide_1.2.md#bending-and-soldering-hall-sensors).
+The way to do them right is to cut the pins flush and reflow them per [the build guide](For_Makers/Build_Guide_1.2.md#bending-and-soldering-hall-sensors).
 
 There are 3 other fixes that resolve the issue.
 
@@ -23,13 +23,13 @@ Temporarily - unscrew the shell screws by 3/4s of a turn.
 
 Unscrew the following screws 3/4s of a turn so that it takes off the pressure on the hall sensor joints.
 
-![Shell Screws](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BoardFixPics/screws_2.jpg?raw=true)
+![Shell Screws](For_Makers/BoardFixPics/screws_2.jpg?raw=true)
 
 Filing - File down the trigger guard at the circled points.
 
 Take out the two black screws holding it in place and remove the trigger guard. Proceed to file down the left trigger guard in the circled locations below to ensure that the joints are not being stressed.
 
-![Trimmed TG HES](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BoardFixPics/hes_tg.jpg?raw=true)
+![Trimmed TG HES](For_Makers/BoardFixPics/hes_tg.jpg?raw=true)
 
 
 3D Print - Either 3D print yourself or order the 3D printed bracket from a service such as JLC and swap it out.
@@ -41,7 +41,7 @@ Take out the two black screws holding it in place and remove the trigger guard. 
 As a result of the hall effect sensor placement, the analog stick is positioned upside down. This causes the notch in the skirt of the analog stick to not line up with the solder joint of the analog slider.
 There are 3 fixes that resolve the issue.
 
-![Trigger Joint](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BoardFixPics/trigger_joint.jpg?raw=true)
+![Trigger Joint](For_Makers/BoardFixPics/trigger_joint.jpg?raw=true)
 
 During Assembly - Trim the pin flush with the hole and only add a little solder so that the solder wets into the hole. This should result in a flat board on top where it does not interfere with the analog stick.
 
@@ -56,9 +56,9 @@ There are 3 fixes that resolve the issue:
 
 Filing - File down the trigger guard at the bottom of the left screw post so that it is flush with the hole as shown below. You only need to remove 0.25mm of material.
 
-![Trimmed TG JST](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BoardFixPics/jst_tg2.jpg?raw=true)
+![Trimmed TG JST](For_Makers/BoardFixPics/jst_tg2.jpg?raw=true)
 
-![INVENTOR EXAMPLE JST TG](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BoardFixPics/jst_tg.png?raw=true)
+![INVENTOR EXAMPLE JST TG](For_Makers/BoardFixPics/jst_tg.png?raw=true)
 
 3D Print - Either 3D print yourself or order the 3D printed bracket from a service such as JLC and swap it out.
 

--- a/For_Makers/Board_Fixes.md
+++ b/For_Makers/Board_Fixes.md
@@ -8,7 +8,7 @@ Please ask in the [PhobGCC Discord Server](https://discord.gg/yrpUu7mgzm) if you
 
 Bridge the third and fourth pins on the top left of the Teensy 3.2/Teensy 4.0 (as seen below) and flash the proper Diode_Short version of the firmware.
 
-![Full Duplex Picture](For_Makers/BoardFixPics/full_duplex.jpg?raw=true)
+![Full Duplex Picture](For_Makers/BoardFixPics/full_duplex.jpg)
 
 ## L-stick Hall Sensor Joints - PhobGCC v1.X
 
@@ -23,13 +23,13 @@ Temporarily - unscrew the shell screws by 3/4s of a turn.
 
 Unscrew the following screws 3/4s of a turn so that it takes off the pressure on the hall sensor joints.
 
-![Shell Screws](For_Makers/BoardFixPics/screws_2.jpg?raw=true)
+![Shell Screws](For_Makers/BoardFixPics/screws_2.jpg)
 
 Filing - File down the trigger guard at the circled points.
 
 Take out the two black screws holding it in place and remove the trigger guard. Proceed to file down the left trigger guard in the circled locations below to ensure that the joints are not being stressed.
 
-![Trimmed TG HES](For_Makers/BoardFixPics/hes_tg.jpg?raw=true)
+![Trimmed TG HES](For_Makers/BoardFixPics/hes_tg.jpg)
 
 
 3D Print - Either 3D print yourself or order the 3D printed bracket from a service such as JLC and swap it out.
@@ -41,7 +41,7 @@ Take out the two black screws holding it in place and remove the trigger guard. 
 As a result of the hall effect sensor placement, the analog stick is positioned upside down. This causes the notch in the skirt of the analog stick to not line up with the solder joint of the analog slider.
 There are 3 fixes that resolve the issue.
 
-![Trigger Joint](For_Makers/BoardFixPics/trigger_joint.jpg?raw=true)
+![Trigger Joint](For_Makers/BoardFixPics/trigger_joint.jpg)
 
 During Assembly - Trim the pin flush with the hole and only add a little solder so that the solder wets into the hole. This should result in a flat board on top where it does not interfere with the analog stick.
 
@@ -56,9 +56,9 @@ There are 3 fixes that resolve the issue:
 
 Filing - File down the trigger guard at the bottom of the left screw post so that it is flush with the hole as shown below. You only need to remove 0.25mm of material.
 
-![Trimmed TG JST](For_Makers/BoardFixPics/jst_tg2.jpg?raw=true)
+![Trimmed TG JST](For_Makers/BoardFixPics/jst_tg2.jpg)
 
-![INVENTOR EXAMPLE JST TG](For_Makers/BoardFixPics/jst_tg.png?raw=true)
+![INVENTOR EXAMPLE JST TG](For_Makers/BoardFixPics/jst_tg.png)
 
 3D Print - Either 3D print yourself or order the 3D printed bracket from a service such as JLC and swap it out.
 

--- a/For_Makers/Board_Level_Debugging_1.2.md
+++ b/For_Makers/Board_Level_Debugging_1.2.md
@@ -6,20 +6,20 @@ You will need a multimeter that can read voltages and resistances to make the mo
 
 # Physical Aspects to Check
 
-![Back of board with annotations](For_Makers/BoardPics/1.2.1_Back_Annotated.jpg)
+![Back of board with annotations](../For_Makers/BoardPics/1.2.1_Back_Annotated.jpg)
 
 * On the Z-button, be very generous with solder on the legs that are on the edge of the board. These solder joints are structural, helping keep the button from breaking off when you mash grab (or Z-jump).
 * The pins behind the Teensy must be flush as possible. The closer they are to completely flat with the board, the flatter the rumble bracket fits. If they protrude, the rumble bracket will always try to pop out.
 * The Hall effect sensors for the Analog stick need to have their leads trimmed fairly closely to the board, though they don't have to be completely flush. If you don't, they press into the trigger guards, the plastic parts that are screwed down over the triggers. This makes it difficult to close the controller shell.
 * The Hall effect sensors on the C-stick board do not have to be trimmed particularly closely.
 
-![Back of analog stick](For_Makers/BoardPics/1.2.1_Back_Rumble_Trim.jpg)
+![Back of analog stick](../For_Makers/BoardPics/1.2.1_Back_Rumble_Trim.jpg)
 
 * The rumble bracket has a loop here that needs to be trimmed off to allow the bracket to lay flat easily.
 
 # Resistances to Check Before Plugging In
 
-![Power-off resistances](For_Makers/BoardPics/1.2.1_Front_Power_Resistances.jpg)
+![Power-off resistances](../For_Makers/BoardPics/1.2.1_Front_Power_Resistances.jpg)
 
 * Check these resistances before ever plugging in the controller to ensure that there are no short-circuits.
 * The 32 Ohm one will be different if you don't have an OEM rumble motor.
@@ -37,7 +37,7 @@ If your controller is not functioning correctly, open the shell and plug it into
 
 ## Supply Voltages
 
-![Power-on supply voltages](For_Makers/BoardPics/1.2.1_Front_Power_Voltages.jpg)
+![Power-on supply voltages](../For_Makers/BoardPics/1.2.1_Front_Power_Voltages.jpg)
 
 * These are the supply voltages for the various parts on the controller.
 * 4.2-4.7V is the supply for the Teensy. This may vary depending on what the controller is plugged into and what the Teensy's clock speed is set to.
@@ -52,7 +52,7 @@ If your controller is not functioning correctly, open the shell and plug it into
 
 If you have particular analog sensors (Analog stick, C-stick, or triggers) that are acting up, check the following voltages to compare:
 
-![Sensor output voltages](For_Makers/BoardPics/1.2.1_Front_Analog_Voltages.jpg)
+![Sensor output voltages](../For_Makers/BoardPics/1.2.1_Front_Analog_Voltages.jpg)
 
 * Put the black lead of your multimeter where Reference Ground indicates and the red lead on the indicated test points.
 * All the 1V values are outputs of the Hall effect sensors.

--- a/For_Makers/Board_Level_Debugging_1.2.md
+++ b/For_Makers/Board_Level_Debugging_1.2.md
@@ -6,20 +6,20 @@ You will need a multimeter that can read voltages and resistances to make the mo
 
 # Physical Aspects to Check
 
-![Back of board with annotations](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BoardPics/1.2.1_Back_Annotated.jpg?raw=true)
+![Back of board with annotations](For_Makers/BoardPics/1.2.1_Back_Annotated.jpg?raw=true)
 
 * On the Z-button, be very generous with solder on the legs that are on the edge of the board. These solder joints are structural, helping keep the button from breaking off when you mash grab (or Z-jump).
 * The pins behind the Teensy must be flush as possible. The closer they are to completely flat with the board, the flatter the rumble bracket fits. If they protrude, the rumble bracket will always try to pop out.
 * The Hall effect sensors for the Analog stick need to have their leads trimmed fairly closely to the board, though they don't have to be completely flush. If you don't, they press into the trigger guards, the plastic parts that are screwed down over the triggers. This makes it difficult to close the controller shell.
 * The Hall effect sensors on the C-stick board do not have to be trimmed particularly closely.
 
-![Back of analog stick](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BoardPics/1.2.1_Back_Rumble_Trim.jpg?raw=true)
+![Back of analog stick](For_Makers/BoardPics/1.2.1_Back_Rumble_Trim.jpg?raw=true)
 
 * The rumble bracket has a loop here that needs to be trimmed off to allow the bracket to lay flat easily.
 
 # Resistances to Check Before Plugging In
 
-![Power-off resistances](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BoardPics/1.2.1_Front_Power_Resistances.jpg?raw=true)
+![Power-off resistances](For_Makers/BoardPics/1.2.1_Front_Power_Resistances.jpg?raw=true)
 
 * Check these resistances before ever plugging in the controller to ensure that there are no short-circuits.
 * The 32 Ohm one will be different if you don't have an OEM rumble motor.
@@ -37,7 +37,7 @@ If your controller is not functioning correctly, open the shell and plug it into
 
 ## Supply Voltages
 
-![Power-on supply voltages](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BoardPics/1.2.1_Front_Power_Voltages.jpg?raw=true)
+![Power-on supply voltages](For_Makers/BoardPics/1.2.1_Front_Power_Voltages.jpg?raw=true)
 
 * These are the supply voltages for the various parts on the controller.
 * 4.2-4.7V is the supply for the Teensy. This may vary depending on what the controller is plugged into and what the Teensy's clock speed is set to.
@@ -52,7 +52,7 @@ If your controller is not functioning correctly, open the shell and plug it into
 
 If you have particular analog sensors (Analog stick, C-stick, or triggers) that are acting up, check the following voltages to compare:
 
-![Sensor output voltages](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BoardPics/1.2.1_Front_Analog_Voltages.jpg?raw=true)
+![Sensor output voltages](For_Makers/BoardPics/1.2.1_Front_Analog_Voltages.jpg?raw=true)
 
 * Put the black lead of your multimeter where Reference Ground indicates and the red lead on the indicated test points.
 * All the 1V values are outputs of the Hall effect sensors.

--- a/For_Makers/Board_Level_Debugging_1.2.md
+++ b/For_Makers/Board_Level_Debugging_1.2.md
@@ -6,20 +6,20 @@ You will need a multimeter that can read voltages and resistances to make the mo
 
 # Physical Aspects to Check
 
-![Back of board with annotations](For_Makers/BoardPics/1.2.1_Back_Annotated.jpg?raw=true)
+![Back of board with annotations](For_Makers/BoardPics/1.2.1_Back_Annotated.jpg)
 
 * On the Z-button, be very generous with solder on the legs that are on the edge of the board. These solder joints are structural, helping keep the button from breaking off when you mash grab (or Z-jump).
 * The pins behind the Teensy must be flush as possible. The closer they are to completely flat with the board, the flatter the rumble bracket fits. If they protrude, the rumble bracket will always try to pop out.
 * The Hall effect sensors for the Analog stick need to have their leads trimmed fairly closely to the board, though they don't have to be completely flush. If you don't, they press into the trigger guards, the plastic parts that are screwed down over the triggers. This makes it difficult to close the controller shell.
 * The Hall effect sensors on the C-stick board do not have to be trimmed particularly closely.
 
-![Back of analog stick](For_Makers/BoardPics/1.2.1_Back_Rumble_Trim.jpg?raw=true)
+![Back of analog stick](For_Makers/BoardPics/1.2.1_Back_Rumble_Trim.jpg)
 
 * The rumble bracket has a loop here that needs to be trimmed off to allow the bracket to lay flat easily.
 
 # Resistances to Check Before Plugging In
 
-![Power-off resistances](For_Makers/BoardPics/1.2.1_Front_Power_Resistances.jpg?raw=true)
+![Power-off resistances](For_Makers/BoardPics/1.2.1_Front_Power_Resistances.jpg)
 
 * Check these resistances before ever plugging in the controller to ensure that there are no short-circuits.
 * The 32 Ohm one will be different if you don't have an OEM rumble motor.
@@ -37,7 +37,7 @@ If your controller is not functioning correctly, open the shell and plug it into
 
 ## Supply Voltages
 
-![Power-on supply voltages](For_Makers/BoardPics/1.2.1_Front_Power_Voltages.jpg?raw=true)
+![Power-on supply voltages](For_Makers/BoardPics/1.2.1_Front_Power_Voltages.jpg)
 
 * These are the supply voltages for the various parts on the controller.
 * 4.2-4.7V is the supply for the Teensy. This may vary depending on what the controller is plugged into and what the Teensy's clock speed is set to.
@@ -52,7 +52,7 @@ If your controller is not functioning correctly, open the shell and plug it into
 
 If you have particular analog sensors (Analog stick, C-stick, or triggers) that are acting up, check the following voltages to compare:
 
-![Sensor output voltages](For_Makers/BoardPics/1.2.1_Front_Analog_Voltages.jpg?raw=true)
+![Sensor output voltages](For_Makers/BoardPics/1.2.1_Front_Analog_Voltages.jpg)
 
 * Put the black lead of your multimeter where Reference Ground indicates and the red lead on the indicated test points.
 * All the 1V values are outputs of the Hall effect sensors.

--- a/For_Makers/Build_Guide_1.2.md
+++ b/For_Makers/Build_Guide_1.2.md
@@ -76,7 +76,7 @@ If you're using 3D-printed magnet holders, you can do this right before putting 
 First press-fit the magnet holders over the pegs on the stickboxes, add a thin coat of superglue inside the magnet holder, then press-fit the magnets themselves into the magnet holders.
 Consult [this section of the PhobGCC 1.2 Assembly Video](https://www.youtube.com/watch?v=0QmgswFa1cA&t=1858s).
 
-![Magnet Holders on Stickboxes](For_Makers/BuildPics_1.2.2/CVAC1076_LwKzi7N-output.jpg?raw=true)
+![Magnet Holders on Stickboxes](For_Makers/BuildPics_1.2.2/CVAC1076_LwKzi7N-output.jpg)
 
 Make sure the magnets are oriented horizontally.
 
@@ -193,21 +193,21 @@ Insert two 14-pin strips and one 2-pin strip of low-profile header pins into the
 
 Place the already-programmed Teensy 4.0 atop the header pins, then solder the Teensy to the pins.
 
-![Teensy soldered to pins](For_Makers/BuildPics_1.2.2/CVAC1053_xHQM57n-output.jpg?raw=true)
+![Teensy soldered to pins](For_Makers/BuildPics_1.2.2/CVAC1053_xHQM57n-output.jpg)
 
 Next, flip the board over and either support the board by the Teensy or securely tape the Teensy to the board so that the pins stick up.
 
-![Teensy pins sticking out](For_Makers/BuildPics_1.2.2/CVAC1050_6Swxhvf-output.jpg?raw=true)
+![Teensy pins sticking out](For_Makers/BuildPics_1.2.2/CVAC1050_6Swxhvf-output.jpg)
 
 Cut the pins as flush as possible to the back of the board. If you don't cut these flush, the rumble bracket may not fit well and the shell won't close easily.
 
-![Trimmed Teensy pins](For_Makers/BuildPics_1.2.2/CVAC1055_uyPRa19-output.jpg?raw=true)
+![Trimmed Teensy pins](For_Makers/BuildPics_1.2.2/CVAC1055_uyPRa19-output.jpg)
 
 Solder the pins to the board, making sure the Teensy remains flush to the board and the vias that the pins reside in are not overfilled with solder.
 
-![Teensy pins soldered in board](For_Makers/BuildPics_1.2.2/CVAC1057_ebm7iTX-output.jpg?raw=true)
+![Teensy pins soldered in board](For_Makers/BuildPics_1.2.2/CVAC1057_ebm7iTX-output.jpg)
 
-![Detail of flush Teensy pins](For_Makers/BuildPics_1.2.2/CVAC1059_c8QvFmk-output.jpg?raw=true)
+![Detail of flush Teensy pins](For_Makers/BuildPics_1.2.2/CVAC1059_c8QvFmk-output.jpg)
 
 ## Trigger Potentiometer Soldering
 
@@ -215,11 +215,11 @@ See [this section of the PhobGCC 1.2 Assembly Video](https://www.youtube.com/wat
 
 Mount the trigger potentiometers to the back of the board. Do not mount them to the same side as the Teensy.
 
-![Trigger pots in board](For_Makers/BuildPics_1.2.2/CVAC1061_tlAv7ii-output.jpg?raw=true)
+![Trigger pots in board](For_Makers/BuildPics_1.2.2/CVAC1061_tlAv7ii-output.jpg)
 
 You can tape them to the board with masking tape to keep them in place, or just rest the board on top of the potentiometers to secure then in place while you solder them.
 
-![Trigger pot soldered](For_Makers/BuildPics_1.2.2/CVAC1064_13Cc9xX-output.jpg?raw=true)
+![Trigger pot soldered](For_Makers/BuildPics_1.2.2/CVAC1064_13Cc9xX-output.jpg)
 
 ## Z-button Switch Soldering
 
@@ -227,11 +227,11 @@ See [this section of the PhobGCC 1.2 Assembly Video](https://www.youtube.com/wat
 
 Mount the Z-button switch to the top of the board, the same side as the Teensy. Do not mount it to the back of the board.
 
-![Z button in place](For_Makers/BuildPics_1.2.2/CVAC1065_234FbNB-output.jpg?raw=true)
+![Z button in place](For_Makers/BuildPics_1.2.2/CVAC1065_234FbNB-output.jpg)
 
 Solder it to the board, with extra solder applied to the contacts at the board edge. These are structural.
 
-![Z button soldered](For_Makers/BuildPics_1.2.2/CVAC1066_BqESr4m-output.jpg?raw=true)
+![Z button soldered](For_Makers/BuildPics_1.2.2/CVAC1066_BqESr4m-output.jpg)
 
 You do not need to solder the inner pads on the board edge.
 
@@ -243,23 +243,23 @@ This does not enhance the feel of the buttons, but it makes them harder to press
 
 First, observe the wings on the button pads. The wings are where the switch contacts will go.
 
-![Dpad no switches](For_Makers/BuildPics_1.2.2/CVAC1067_eu3QgqE-output.jpg?raw=true)
+![Dpad no switches](For_Makers/BuildPics_1.2.2/CVAC1067_eu3QgqE-output.jpg)
 
 The switches on the right and left pads must be oriented with the contacts oriented horizontally, while the switches on the top and bottom pads must be oriented with the contacts oriented vertically.
 
 If you mix this up, the buttons will be shorting the contacts all the time.
 
-![Dpad 2 switches placed](For_Makers/BuildPics_1.2.2/CVAC1070_6bdEB3t-output.jpg?raw=true)
+![Dpad 2 switches placed](For_Makers/BuildPics_1.2.2/CVAC1070_6bdEB3t-output.jpg)
 
 The process of soldering goes as shown:
 
-![Dpad 3 switches placed, solder process](For_Makers/BuildPics_1.2.2/CVAC1071_kyUKuIA-output.jpg?raw=true)
+![Dpad 3 switches placed, solder process](For_Makers/BuildPics_1.2.2/CVAC1071_kyUKuIA-output.jpg)
 
 Top: Apply a tiny bit of solder to one wing of the contact only.
 
 Left: Using tweezers, hold a switch in place and melt the existing solder to tack it in place. Do all the buttons to this stage, then fit-check their placement using the shell to make sure they are centered under the rubber domes..
 
-![Fit checking dpad](For_Makers/BuildPics_1.2.2/CVAC1074_U2HLUVJ-output.jpg?raw=true)
+![Fit checking dpad](For_Makers/BuildPics_1.2.2/CVAC1074_U2HLUVJ-output.jpg)
 
 Right: Tack the opposite corner down using solder, then remelt the first corner and then this corner to eliminate strain.
 
@@ -267,7 +267,7 @@ Bottom: Solder down the rest of the corners.
 
 The buttons should now look like this:
 
-![All dpad buttons](For_Makers/BuildPics_1.2.2/CVAC1072_1oL78HD-output.jpg?raw=true)
+![All dpad buttons](For_Makers/BuildPics_1.2.2/CVAC1072_1oL78HD-output.jpg)
 
 Using a multimeter, check continuity between the exposed copper pads that stick out past the button. They should be disconnected when the switch isn't pressed, and shorted when the switch is pressed.
 
@@ -278,47 +278,47 @@ Also see [the PhobGCC Hall Effect Sensor Soldering Video](https://www.youtube.co
 
 The Hall effect sensors come as a small black prism with two beveled edges.
 
-![Straight hall sensor](For_Makers/BuildPics_1.2.2/CVAC1077_yWpEYon-output.jpg?raw=true)
+![Straight hall sensor](For_Makers/BuildPics_1.2.2/CVAC1077_yWpEYon-output.jpg)
 
 The legs of the Hall effect sensors must be bent 90 degrees so that the beveled edges face upward, with the bend as close as possible to the head of the sensor.
 
-![Bent hall sensor](For_Makers/BuildPics_1.2.2/CVAC1080_UY7wI4g-output.jpg?raw=true)
+![Bent hall sensor](For_Makers/BuildPics_1.2.2/CVAC1080_UY7wI4g-output.jpg)
 
 If the bends are located too far away from the body of the sensor, it will be difficult to get the stickbox in place.
 
 Place the bent sensors in the board with the legs through the holes.
 Make sure they are on the upper side of the board with the text; this is easy to mix up on the C-stick board.
 
-![Hall sensors on C-stick board](For_Makers/BuildPics_1.2.2/CVAC1081_zGE2DdR-output.jpg?raw=true)
+![Hall sensors on C-stick board](For_Makers/BuildPics_1.2.2/CVAC1081_zGE2DdR-output.jpg)
 
 On the motherboard, place the Hall sensors on the top and left sides where the pads are small and close together.
 Do not try to spread the Hall sensor legs to fit through the wider-spaced holes on the bottom and right sides; you may break the sensor and it won't work even if you manage to not break them.
 
-![Hall sensors on motherboard](For_Makers/BuildPics_1.2.2/CVAC1088_BGdBDFf-output.jpg?raw=true)
+![Hall sensors on motherboard](For_Makers/BuildPics_1.2.2/CVAC1088_BGdBDFf-output.jpg)
 
 Install the stickboxes, already equipped with magnets, on the boards before soldering down the Hall sensors.
 
-![stickbox on c-stick board](For_Makers/BuildPics_1.2.2/CVAC1083_ydmlexH-output.jpg?raw=true)
+![stickbox on c-stick board](For_Makers/BuildPics_1.2.2/CVAC1083_ydmlexH-output.jpg)
 
-![stickbox on motherboard](For_Makers/BuildPics_1.2.2/CVAC1090_N3j5WHq-output.jpg?raw=true)
+![stickbox on motherboard](For_Makers/BuildPics_1.2.2/CVAC1090_N3j5WHq-output.jpg)
 
 Align the height of the sensors to be roughly the level of this feature in the T3 stickbox or lower, making sure the sensors are centered and level.
 You may need to bend the legs a bit.
 
-![stickbox height reference](For_Makers/BuildPics_1.2.2/CVAC1083_annotated.jpg?raw=true)
+![stickbox height reference](For_Makers/BuildPics_1.2.2/CVAC1083_annotated.jpg)
 
 When you are satisfied with the sensor height, solder one leg in place.
 You can then use tweezers to manipulate the position while you remelt that one solder joint in order to fine-tune it.
 
-![one hall leg soldered](For_Makers/BuildPics_1.2.2/CVAC1084_woadHfG-output.jpg?raw=true)
+![one hall leg soldered](For_Makers/BuildPics_1.2.2/CVAC1084_woadHfG-output.jpg)
 
 Then, solder the remainder of the legs.
 
-![all hall legs soldered](For_Makers/BuildPics_1.2.2/CVAC1085_28epqhF-output.jpg?raw=true)
+![all hall legs soldered](For_Makers/BuildPics_1.2.2/CVAC1085_28epqhF-output.jpg)
 
 Finally, trim the legs.
 
-![c-stick hall legs trimmed](For_Makers/BuildPics_1.2.2/CVAC1087_9D4zsuI-output.jpg?raw=true)
+![c-stick hall legs trimmed](For_Makers/BuildPics_1.2.2/CVAC1087_9D4zsuI-output.jpg)
 
 On the motherboard, trim the legs *very closely* and then reflow the solder on each joint.
 They should be no taller than half the height of the screw heads for the stickbox.
@@ -332,7 +332,7 @@ This commonly causes a short-circuit, which does no damage but makes the analog 
 Using SAC305 solder, which is harder, seems to have fewer issues.
 And as mentioned before, make sure that the Hall sensor solder joints are as flat to the board as you can make them, to help mitigate this issue.
 
-![motherboard hall legs trimmed](For_Makers/BuildPics_1.2.2/CVAC1095_b35fEvP-output.jpg?raw=true)
+![motherboard hall legs trimmed](For_Makers/BuildPics_1.2.2/CVAC1095_b35fEvP-output.jpg)
 
 ## C-stick Cable Soldering
 
@@ -342,20 +342,20 @@ You can either use the ribbon cable harvested from the OEM board, or you can sol
 
 Since I'm using the OEM cable, I prefer to put the red line on the side with the square pad on the C-stick board.
 
-![Cable in c-stick board](For_Makers/BuildPics_1.2.2/CVAC1096_pR6Srfa-output.jpg?raw=true)
+![Cable in c-stick board](For_Makers/BuildPics_1.2.2/CVAC1096_pR6Srfa-output.jpg)
 
 Solder the exposed ends to the pads.
 
-![Cable soldered to c-stick board](For_Makers/BuildPics_1.2.2/CVAC1097_XgsctHq-output.jpg?raw=true)
+![Cable soldered to c-stick board](For_Makers/BuildPics_1.2.2/CVAC1097_XgsctHq-output.jpg)
 
 Next, connect the opposite end of either the ribbon cable or the wires to the motherboard.
 Make sure that both boards are facing up, and make sure they are oriented like this to ensure that the connections do not get mixed up.
 
-![Cable connecting c-stick to motherboard](For_Makers/BuildPics_1.2.2/CVAC1100_dQf9AKg-output.jpg?raw=true)
+![Cable connecting c-stick to motherboard](For_Makers/BuildPics_1.2.2/CVAC1100_dQf9AKg-output.jpg)
 
 Then, solder the wires to the motherboard.
 
-![C-stick cable soldered to motherboard](For_Makers/BuildPics_1.2.2/CVAC1101_oiRxotI-output.jpg?raw=true)
+![C-stick cable soldered to motherboard](For_Makers/BuildPics_1.2.2/CVAC1101_oiRxotI-output.jpg)
 
 ## Controller Cable Soldering
 
@@ -363,11 +363,11 @@ See [this section of the PhobGCC 1.2 Assembly Video](https://www.youtube.com/wat
 
 If you are using an OEM cable harvested from a first-party Gamecube controller, the black wire should be placed farthest from the center of the controller, and the blue wire closest to the center of the controller.
 
-![Controller cable colors](For_Makers/BuildPics_1.2.2/CVAC1106_nKaZ4km-output.jpg?raw=true)
+![Controller cable colors](For_Makers/BuildPics_1.2.2/CVAC1106_nKaZ4km-output.jpg)
 
 The pins themselves are actually basketlike sheet metal forms, so when you solder them, they take up a fairly large amount of solder.
 
-![Controller cable soldered](For_Makers/BuildPics_1.2.2/CVAC1107_Khu6BvC-output.jpg?raw=true)
+![Controller cable soldered](For_Makers/BuildPics_1.2.2/CVAC1107_Khu6BvC-output.jpg)
 
 ## Trigger Paddle Soldering
 
@@ -379,42 +379,42 @@ Cut and strip wires that are roughly 1 inch long (25mm), and solder them in so t
 
 Do not have the wires exit the front side with the contacts, or they can short to the Hall effect sensor pins.
 
-![Wires soldered into trigger paddles](For_Makers/BuildPics_1.2.2/CVAC1108_AFMbsiO-output.jpg?raw=true)
+![Wires soldered into trigger paddles](For_Makers/BuildPics_1.2.2/CVAC1108_AFMbsiO-output.jpg)
 
 Load the trigger paddles with pads exposed into the rumble bracket (whether OEM or third-party), and mount the rumble bracket to the PCB.
 Make sure the wires safely exit the slots and do not get caught or pinched under the bracket.
 
-![Trigger wires in slots of rumble bracket](For_Makers/BuildPics_1.2.2/CVAC1109_6LWiGDH-output.jpg?raw=true)
+![Trigger wires in slots of rumble bracket](For_Makers/BuildPics_1.2.2/CVAC1109_6LWiGDH-output.jpg)
 
 Tuck the trigger paddle wires into the nearby holes in the motherboard.
 
-![Trigger wires in holes](For_Makers/BuildPics_1.2.2/CVAC1111_N0bJKZt-output.jpg?raw=true)
+![Trigger wires in holes](For_Makers/BuildPics_1.2.2/CVAC1111_N0bJKZt-output.jpg)
 
 Then, being careful not to let them slip out, solder them to the motherboard.
 
-![Trigger wires soldered](For_Makers/BuildPics_1.2.2/CVAC1112_xdrTBOe-output.jpg?raw=true)
+![Trigger wires soldered](For_Makers/BuildPics_1.2.2/CVAC1112_xdrTBOe-output.jpg)
 
 ## Rumble Motor Soldering
 
 Next, mount the rumble motor back in the rumble bracket by inserting it into the rectangular box.
 Make sure that the shaft is on the cable side, and the motor is rotated so that the wires are on the D-pad side, close to the edge of the box.
 
-![Rumble motor in place](For_Makers/BuildPics_1.2.2/CVAC1113_9EfRr5r-output.jpg?raw=true)
+![Rumble motor in place](For_Makers/BuildPics_1.2.2/CVAC1113_9EfRr5r-output.jpg)
 
 Apply a generous blob of solder to each of the rumble motor pads.
 
-![Rumble motor solder blobs](For_Makers/BuildPics_1.2.2/CVAC1115_Kc7aSfL-output.jpg?raw=true)
+![Rumble motor solder blobs](For_Makers/BuildPics_1.2.2/CVAC1115_Kc7aSfL-output.jpg)
 
 To solder the wires down, melt the blob of solder with your soldering iron and use tweezers to hold the wire in the pool.
 Remove the hot soldering iron, and keep the wire still as the solder cools.
 
 Clip the wires into place on the rumble bracket.
 
-![Rumble motor wires soldered](For_Makers/BuildPics_1.2.2/CVAC1116_YjbJXub-output.jpg?raw=true)
+![Rumble motor wires soldered](For_Makers/BuildPics_1.2.2/CVAC1116_YjbJXub-output.jpg)
 
 # Completion and next steps
 
-![PhobGCC 1.2.2 complete](For_Makers/BuildPics_1.2.2/CVAC1118_1lwoupq-output.jpg?raw=true)
+![PhobGCC 1.2.2 complete](For_Makers/BuildPics_1.2.2/CVAC1118_1lwoupq-output.jpg)
 
 Now that you have completed the soldering steps, follow the [Board Debugging Guide for PhobGCC 1.2](For_Makers/Board_Level_Debugging_1.2.md) to make sure it's ready to go.
 

--- a/For_Makers/Build_Guide_1.2.md
+++ b/For_Makers/Build_Guide_1.2.md
@@ -76,7 +76,7 @@ If you're using 3D-printed magnet holders, you can do this right before putting 
 First press-fit the magnet holders over the pegs on the stickboxes, add a thin coat of superglue inside the magnet holder, then press-fit the magnets themselves into the magnet holders.
 Consult [this section of the PhobGCC 1.2 Assembly Video](https://www.youtube.com/watch?v=0QmgswFa1cA&t=1858s).
 
-![Magnet Holders on Stickboxes](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1076_LwKzi7N-output.jpg?raw=true)
+![Magnet Holders on Stickboxes](For_Makers/BuildPics_1.2.2/CVAC1076_LwKzi7N-output.jpg?raw=true)
 
 Make sure the magnets are oriented horizontally.
 
@@ -183,7 +183,7 @@ To remedy this, use rubbing alcohol (as high concentration as you can get) with 
 
 ## Teensy Programming
 
-Begin by programming the Teensy 4.0 according to [this guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Programming_Guide.md).
+Begin by programming the Teensy 4.0 according to [this guide](For_Users/Phob_Programming_Guide.md).
 
 ## Teensy Soldering
 
@@ -193,21 +193,21 @@ Insert two 14-pin strips and one 2-pin strip of low-profile header pins into the
 
 Place the already-programmed Teensy 4.0 atop the header pins, then solder the Teensy to the pins.
 
-![Teensy soldered to pins](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1053_xHQM57n-output.jpg?raw=true)
+![Teensy soldered to pins](For_Makers/BuildPics_1.2.2/CVAC1053_xHQM57n-output.jpg?raw=true)
 
 Next, flip the board over and either support the board by the Teensy or securely tape the Teensy to the board so that the pins stick up.
 
-![Teensy pins sticking out](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1050_6Swxhvf-output.jpg?raw=true)
+![Teensy pins sticking out](For_Makers/BuildPics_1.2.2/CVAC1050_6Swxhvf-output.jpg?raw=true)
 
 Cut the pins as flush as possible to the back of the board. If you don't cut these flush, the rumble bracket may not fit well and the shell won't close easily.
 
-![Trimmed Teensy pins](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1055_uyPRa19-output.jpg?raw=true)
+![Trimmed Teensy pins](For_Makers/BuildPics_1.2.2/CVAC1055_uyPRa19-output.jpg?raw=true)
 
 Solder the pins to the board, making sure the Teensy remains flush to the board and the vias that the pins reside in are not overfilled with solder.
 
-![Teensy pins soldered in board](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1057_ebm7iTX-output.jpg?raw=true)
+![Teensy pins soldered in board](For_Makers/BuildPics_1.2.2/CVAC1057_ebm7iTX-output.jpg?raw=true)
 
-![Detail of flush Teensy pins](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1059_c8QvFmk-output.jpg?raw=true)
+![Detail of flush Teensy pins](For_Makers/BuildPics_1.2.2/CVAC1059_c8QvFmk-output.jpg?raw=true)
 
 ## Trigger Potentiometer Soldering
 
@@ -215,11 +215,11 @@ See [this section of the PhobGCC 1.2 Assembly Video](https://www.youtube.com/wat
 
 Mount the trigger potentiometers to the back of the board. Do not mount them to the same side as the Teensy.
 
-![Trigger pots in board](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1061_tlAv7ii-output.jpg?raw=true)
+![Trigger pots in board](For_Makers/BuildPics_1.2.2/CVAC1061_tlAv7ii-output.jpg?raw=true)
 
 You can tape them to the board with masking tape to keep them in place, or just rest the board on top of the potentiometers to secure then in place while you solder them.
 
-![Trigger pot soldered](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1064_13Cc9xX-output.jpg?raw=true)
+![Trigger pot soldered](For_Makers/BuildPics_1.2.2/CVAC1064_13Cc9xX-output.jpg?raw=true)
 
 ## Z-button Switch Soldering
 
@@ -227,11 +227,11 @@ See [this section of the PhobGCC 1.2 Assembly Video](https://www.youtube.com/wat
 
 Mount the Z-button switch to the top of the board, the same side as the Teensy. Do not mount it to the back of the board.
 
-![Z button in place](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1065_234FbNB-output.jpg?raw=true)
+![Z button in place](For_Makers/BuildPics_1.2.2/CVAC1065_234FbNB-output.jpg?raw=true)
 
 Solder it to the board, with extra solder applied to the contacts at the board edge. These are structural.
 
-![Z button soldered](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1066_BqESr4m-output.jpg?raw=true)
+![Z button soldered](For_Makers/BuildPics_1.2.2/CVAC1066_BqESr4m-output.jpg?raw=true)
 
 You do not need to solder the inner pads on the board edge.
 
@@ -243,23 +243,23 @@ This does not enhance the feel of the buttons, but it makes them harder to press
 
 First, observe the wings on the button pads. The wings are where the switch contacts will go.
 
-![Dpad no switches](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1067_eu3QgqE-output.jpg?raw=true)
+![Dpad no switches](For_Makers/BuildPics_1.2.2/CVAC1067_eu3QgqE-output.jpg?raw=true)
 
 The switches on the right and left pads must be oriented with the contacts oriented horizontally, while the switches on the top and bottom pads must be oriented with the contacts oriented vertically.
 
 If you mix this up, the buttons will be shorting the contacts all the time.
 
-![Dpad 2 switches placed](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1070_6bdEB3t-output.jpg?raw=true)
+![Dpad 2 switches placed](For_Makers/BuildPics_1.2.2/CVAC1070_6bdEB3t-output.jpg?raw=true)
 
 The process of soldering goes as shown:
 
-![Dpad 3 switches placed, solder process](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1071_kyUKuIA-output.jpg?raw=true)
+![Dpad 3 switches placed, solder process](For_Makers/BuildPics_1.2.2/CVAC1071_kyUKuIA-output.jpg?raw=true)
 
 Top: Apply a tiny bit of solder to one wing of the contact only.
 
 Left: Using tweezers, hold a switch in place and melt the existing solder to tack it in place. Do all the buttons to this stage, then fit-check their placement using the shell to make sure they are centered under the rubber domes..
 
-![Fit checking dpad](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1074_U2HLUVJ-output.jpg?raw=true)
+![Fit checking dpad](For_Makers/BuildPics_1.2.2/CVAC1074_U2HLUVJ-output.jpg?raw=true)
 
 Right: Tack the opposite corner down using solder, then remelt the first corner and then this corner to eliminate strain.
 
@@ -267,7 +267,7 @@ Bottom: Solder down the rest of the corners.
 
 The buttons should now look like this:
 
-![All dpad buttons](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1072_1oL78HD-output.jpg?raw=true)
+![All dpad buttons](For_Makers/BuildPics_1.2.2/CVAC1072_1oL78HD-output.jpg?raw=true)
 
 Using a multimeter, check continuity between the exposed copper pads that stick out past the button. They should be disconnected when the switch isn't pressed, and shorted when the switch is pressed.
 
@@ -278,47 +278,47 @@ Also see [the PhobGCC Hall Effect Sensor Soldering Video](https://www.youtube.co
 
 The Hall effect sensors come as a small black prism with two beveled edges.
 
-![Straight hall sensor](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1077_yWpEYon-output.jpg?raw=true)
+![Straight hall sensor](For_Makers/BuildPics_1.2.2/CVAC1077_yWpEYon-output.jpg?raw=true)
 
 The legs of the Hall effect sensors must be bent 90 degrees so that the beveled edges face upward, with the bend as close as possible to the head of the sensor.
 
-![Bent hall sensor](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1080_UY7wI4g-output.jpg?raw=true)
+![Bent hall sensor](For_Makers/BuildPics_1.2.2/CVAC1080_UY7wI4g-output.jpg?raw=true)
 
 If the bends are located too far away from the body of the sensor, it will be difficult to get the stickbox in place.
 
 Place the bent sensors in the board with the legs through the holes.
 Make sure they are on the upper side of the board with the text; this is easy to mix up on the C-stick board.
 
-![Hall sensors on C-stick board](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1081_zGE2DdR-output.jpg?raw=true)
+![Hall sensors on C-stick board](For_Makers/BuildPics_1.2.2/CVAC1081_zGE2DdR-output.jpg?raw=true)
 
 On the motherboard, place the Hall sensors on the top and left sides where the pads are small and close together.
 Do not try to spread the Hall sensor legs to fit through the wider-spaced holes on the bottom and right sides; you may break the sensor and it won't work even if you manage to not break them.
 
-![Hall sensors on motherboard](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1088_BGdBDFf-output.jpg?raw=true)
+![Hall sensors on motherboard](For_Makers/BuildPics_1.2.2/CVAC1088_BGdBDFf-output.jpg?raw=true)
 
 Install the stickboxes, already equipped with magnets, on the boards before soldering down the Hall sensors.
 
-![stickbox on c-stick board](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1083_ydmlexH-output.jpg?raw=true)
+![stickbox on c-stick board](For_Makers/BuildPics_1.2.2/CVAC1083_ydmlexH-output.jpg?raw=true)
 
-![stickbox on motherboard](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1090_N3j5WHq-output.jpg?raw=true)
+![stickbox on motherboard](For_Makers/BuildPics_1.2.2/CVAC1090_N3j5WHq-output.jpg?raw=true)
 
 Align the height of the sensors to be roughly the level of this feature in the T3 stickbox or lower, making sure the sensors are centered and level.
 You may need to bend the legs a bit.
 
-![stickbox height reference](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1083_annotated.jpg?raw=true)
+![stickbox height reference](For_Makers/BuildPics_1.2.2/CVAC1083_annotated.jpg?raw=true)
 
 When you are satisfied with the sensor height, solder one leg in place.
 You can then use tweezers to manipulate the position while you remelt that one solder joint in order to fine-tune it.
 
-![one hall leg soldered](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1084_woadHfG-output.jpg?raw=true)
+![one hall leg soldered](For_Makers/BuildPics_1.2.2/CVAC1084_woadHfG-output.jpg?raw=true)
 
 Then, solder the remainder of the legs.
 
-![all hall legs soldered](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1085_28epqhF-output.jpg?raw=true)
+![all hall legs soldered](For_Makers/BuildPics_1.2.2/CVAC1085_28epqhF-output.jpg?raw=true)
 
 Finally, trim the legs.
 
-![c-stick hall legs trimmed](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1087_9D4zsuI-output.jpg?raw=true)
+![c-stick hall legs trimmed](For_Makers/BuildPics_1.2.2/CVAC1087_9D4zsuI-output.jpg?raw=true)
 
 On the motherboard, trim the legs *very closely* and then reflow the solder on each joint.
 They should be no taller than half the height of the screw heads for the stickbox.
@@ -332,7 +332,7 @@ This commonly causes a short-circuit, which does no damage but makes the analog 
 Using SAC305 solder, which is harder, seems to have fewer issues.
 And as mentioned before, make sure that the Hall sensor solder joints are as flat to the board as you can make them, to help mitigate this issue.
 
-![motherboard hall legs trimmed](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1095_b35fEvP-output.jpg?raw=true)
+![motherboard hall legs trimmed](For_Makers/BuildPics_1.2.2/CVAC1095_b35fEvP-output.jpg?raw=true)
 
 ## C-stick Cable Soldering
 
@@ -342,20 +342,20 @@ You can either use the ribbon cable harvested from the OEM board, or you can sol
 
 Since I'm using the OEM cable, I prefer to put the red line on the side with the square pad on the C-stick board.
 
-![Cable in c-stick board](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1096_pR6Srfa-output.jpg?raw=true)
+![Cable in c-stick board](For_Makers/BuildPics_1.2.2/CVAC1096_pR6Srfa-output.jpg?raw=true)
 
 Solder the exposed ends to the pads.
 
-![Cable soldered to c-stick board](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1097_XgsctHq-output.jpg?raw=true)
+![Cable soldered to c-stick board](For_Makers/BuildPics_1.2.2/CVAC1097_XgsctHq-output.jpg?raw=true)
 
 Next, connect the opposite end of either the ribbon cable or the wires to the motherboard.
 Make sure that both boards are facing up, and make sure they are oriented like this to ensure that the connections do not get mixed up.
 
-![Cable connecting c-stick to motherboard](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1100_dQf9AKg-output.jpg?raw=true)
+![Cable connecting c-stick to motherboard](For_Makers/BuildPics_1.2.2/CVAC1100_dQf9AKg-output.jpg?raw=true)
 
 Then, solder the wires to the motherboard.
 
-![C-stick cable soldered to motherboard](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1101_oiRxotI-output.jpg?raw=true)
+![C-stick cable soldered to motherboard](For_Makers/BuildPics_1.2.2/CVAC1101_oiRxotI-output.jpg?raw=true)
 
 ## Controller Cable Soldering
 
@@ -363,11 +363,11 @@ See [this section of the PhobGCC 1.2 Assembly Video](https://www.youtube.com/wat
 
 If you are using an OEM cable harvested from a first-party Gamecube controller, the black wire should be placed farthest from the center of the controller, and the blue wire closest to the center of the controller.
 
-![Controller cable colors](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1106_nKaZ4km-output.jpg?raw=true)
+![Controller cable colors](For_Makers/BuildPics_1.2.2/CVAC1106_nKaZ4km-output.jpg?raw=true)
 
 The pins themselves are actually basketlike sheet metal forms, so when you solder them, they take up a fairly large amount of solder.
 
-![Controller cable soldered](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1107_Khu6BvC-output.jpg?raw=true)
+![Controller cable soldered](For_Makers/BuildPics_1.2.2/CVAC1107_Khu6BvC-output.jpg?raw=true)
 
 ## Trigger Paddle Soldering
 
@@ -379,46 +379,46 @@ Cut and strip wires that are roughly 1 inch long (25mm), and solder them in so t
 
 Do not have the wires exit the front side with the contacts, or they can short to the Hall effect sensor pins.
 
-![Wires soldered into trigger paddles](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1108_AFMbsiO-output.jpg?raw=true)
+![Wires soldered into trigger paddles](For_Makers/BuildPics_1.2.2/CVAC1108_AFMbsiO-output.jpg?raw=true)
 
 Load the trigger paddles with pads exposed into the rumble bracket (whether OEM or third-party), and mount the rumble bracket to the PCB.
 Make sure the wires safely exit the slots and do not get caught or pinched under the bracket.
 
-![Trigger wires in slots of rumble bracket](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1109_6LWiGDH-output.jpg?raw=true)
+![Trigger wires in slots of rumble bracket](For_Makers/BuildPics_1.2.2/CVAC1109_6LWiGDH-output.jpg?raw=true)
 
 Tuck the trigger paddle wires into the nearby holes in the motherboard.
 
-![Trigger wires in holes](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1111_N0bJKZt-output.jpg?raw=true)
+![Trigger wires in holes](For_Makers/BuildPics_1.2.2/CVAC1111_N0bJKZt-output.jpg?raw=true)
 
 Then, being careful not to let them slip out, solder them to the motherboard.
 
-![Trigger wires soldered](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1112_xdrTBOe-output.jpg?raw=true)
+![Trigger wires soldered](For_Makers/BuildPics_1.2.2/CVAC1112_xdrTBOe-output.jpg?raw=true)
 
 ## Rumble Motor Soldering
 
 Next, mount the rumble motor back in the rumble bracket by inserting it into the rectangular box.
 Make sure that the shaft is on the cable side, and the motor is rotated so that the wires are on the D-pad side, close to the edge of the box.
 
-![Rumble motor in place](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1113_9EfRr5r-output.jpg?raw=true)
+![Rumble motor in place](For_Makers/BuildPics_1.2.2/CVAC1113_9EfRr5r-output.jpg?raw=true)
 
 Apply a generous blob of solder to each of the rumble motor pads.
 
-![Rumble motor solder blobs](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1115_Kc7aSfL-output.jpg?raw=true)
+![Rumble motor solder blobs](For_Makers/BuildPics_1.2.2/CVAC1115_Kc7aSfL-output.jpg?raw=true)
 
 To solder the wires down, melt the blob of solder with your soldering iron and use tweezers to hold the wire in the pool.
 Remove the hot soldering iron, and keep the wire still as the solder cools.
 
 Clip the wires into place on the rumble bracket.
 
-![Rumble motor wires soldered](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1116_YjbJXub-output.jpg?raw=true)
+![Rumble motor wires soldered](For_Makers/BuildPics_1.2.2/CVAC1116_YjbJXub-output.jpg?raw=true)
 
 # Completion and next steps
 
-![PhobGCC 1.2.2 complete](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1118_1lwoupq-output.jpg?raw=true)
+![PhobGCC 1.2.2 complete](For_Makers/BuildPics_1.2.2/CVAC1118_1lwoupq-output.jpg?raw=true)
 
-Now that you have completed the soldering steps, follow the [Board Debugging Guide for PhobGCC 1.2](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Board_Level_Debugging_1.2.md) to make sure it's ready to go.
+Now that you have completed the soldering steps, follow the [Board Debugging Guide for PhobGCC 1.2](For_Makers/Board_Level_Debugging_1.2.md) to make sure it's ready to go.
 
-Then, reassemble it, and follow the Initial Steps in the [PhobGCC Calibration Guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_Latest.md) for the version of the software you have flashed on the Teensy.
+Then, reassemble it, and follow the Initial Steps in the [PhobGCC Calibration Guide](For_Users/Phob_Calibration_Guide_Latest.md) for the version of the software you have flashed on the Teensy.
 
 And, enjoy!
 

--- a/For_Makers/Build_Guide_1.2.md
+++ b/For_Makers/Build_Guide_1.2.md
@@ -76,7 +76,7 @@ If you're using 3D-printed magnet holders, you can do this right before putting 
 First press-fit the magnet holders over the pegs on the stickboxes, add a thin coat of superglue inside the magnet holder, then press-fit the magnets themselves into the magnet holders.
 Consult [this section of the PhobGCC 1.2 Assembly Video](https://www.youtube.com/watch?v=0QmgswFa1cA&t=1858s).
 
-![Magnet Holders on Stickboxes](For_Makers/BuildPics_1.2.2/CVAC1076_LwKzi7N-output.jpg)
+![Magnet Holders on Stickboxes](../For_Makers/BuildPics_1.2.2/CVAC1076_LwKzi7N-output.jpg)
 
 Make sure the magnets are oriented horizontally.
 
@@ -183,7 +183,7 @@ To remedy this, use rubbing alcohol (as high concentration as you can get) with 
 
 ## Teensy Programming
 
-Begin by programming the Teensy 4.0 according to [this guide](For_Users/Phob_Programming_Guide.md).
+Begin by programming the Teensy 4.0 according to [this guide](../For_Users/Phob_Programming_Guide.md).
 
 ## Teensy Soldering
 
@@ -193,21 +193,21 @@ Insert two 14-pin strips and one 2-pin strip of low-profile header pins into the
 
 Place the already-programmed Teensy 4.0 atop the header pins, then solder the Teensy to the pins.
 
-![Teensy soldered to pins](For_Makers/BuildPics_1.2.2/CVAC1053_xHQM57n-output.jpg)
+![Teensy soldered to pins](../For_Makers/BuildPics_1.2.2/CVAC1053_xHQM57n-output.jpg)
 
 Next, flip the board over and either support the board by the Teensy or securely tape the Teensy to the board so that the pins stick up.
 
-![Teensy pins sticking out](For_Makers/BuildPics_1.2.2/CVAC1050_6Swxhvf-output.jpg)
+![Teensy pins sticking out](../For_Makers/BuildPics_1.2.2/CVAC1050_6Swxhvf-output.jpg)
 
 Cut the pins as flush as possible to the back of the board. If you don't cut these flush, the rumble bracket may not fit well and the shell won't close easily.
 
-![Trimmed Teensy pins](For_Makers/BuildPics_1.2.2/CVAC1055_uyPRa19-output.jpg)
+![Trimmed Teensy pins](../For_Makers/BuildPics_1.2.2/CVAC1055_uyPRa19-output.jpg)
 
 Solder the pins to the board, making sure the Teensy remains flush to the board and the vias that the pins reside in are not overfilled with solder.
 
-![Teensy pins soldered in board](For_Makers/BuildPics_1.2.2/CVAC1057_ebm7iTX-output.jpg)
+![Teensy pins soldered in board](../For_Makers/BuildPics_1.2.2/CVAC1057_ebm7iTX-output.jpg)
 
-![Detail of flush Teensy pins](For_Makers/BuildPics_1.2.2/CVAC1059_c8QvFmk-output.jpg)
+![Detail of flush Teensy pins](../For_Makers/BuildPics_1.2.2/CVAC1059_c8QvFmk-output.jpg)
 
 ## Trigger Potentiometer Soldering
 
@@ -215,11 +215,11 @@ See [this section of the PhobGCC 1.2 Assembly Video](https://www.youtube.com/wat
 
 Mount the trigger potentiometers to the back of the board. Do not mount them to the same side as the Teensy.
 
-![Trigger pots in board](For_Makers/BuildPics_1.2.2/CVAC1061_tlAv7ii-output.jpg)
+![Trigger pots in board](../For_Makers/BuildPics_1.2.2/CVAC1061_tlAv7ii-output.jpg)
 
 You can tape them to the board with masking tape to keep them in place, or just rest the board on top of the potentiometers to secure then in place while you solder them.
 
-![Trigger pot soldered](For_Makers/BuildPics_1.2.2/CVAC1064_13Cc9xX-output.jpg)
+![Trigger pot soldered](../For_Makers/BuildPics_1.2.2/CVAC1064_13Cc9xX-output.jpg)
 
 ## Z-button Switch Soldering
 
@@ -227,11 +227,11 @@ See [this section of the PhobGCC 1.2 Assembly Video](https://www.youtube.com/wat
 
 Mount the Z-button switch to the top of the board, the same side as the Teensy. Do not mount it to the back of the board.
 
-![Z button in place](For_Makers/BuildPics_1.2.2/CVAC1065_234FbNB-output.jpg)
+![Z button in place](../For_Makers/BuildPics_1.2.2/CVAC1065_234FbNB-output.jpg)
 
 Solder it to the board, with extra solder applied to the contacts at the board edge. These are structural.
 
-![Z button soldered](For_Makers/BuildPics_1.2.2/CVAC1066_BqESr4m-output.jpg)
+![Z button soldered](../For_Makers/BuildPics_1.2.2/CVAC1066_BqESr4m-output.jpg)
 
 You do not need to solder the inner pads on the board edge.
 
@@ -243,23 +243,23 @@ This does not enhance the feel of the buttons, but it makes them harder to press
 
 First, observe the wings on the button pads. The wings are where the switch contacts will go.
 
-![Dpad no switches](For_Makers/BuildPics_1.2.2/CVAC1067_eu3QgqE-output.jpg)
+![Dpad no switches](../For_Makers/BuildPics_1.2.2/CVAC1067_eu3QgqE-output.jpg)
 
 The switches on the right and left pads must be oriented with the contacts oriented horizontally, while the switches on the top and bottom pads must be oriented with the contacts oriented vertically.
 
 If you mix this up, the buttons will be shorting the contacts all the time.
 
-![Dpad 2 switches placed](For_Makers/BuildPics_1.2.2/CVAC1070_6bdEB3t-output.jpg)
+![Dpad 2 switches placed](../For_Makers/BuildPics_1.2.2/CVAC1070_6bdEB3t-output.jpg)
 
 The process of soldering goes as shown:
 
-![Dpad 3 switches placed, solder process](For_Makers/BuildPics_1.2.2/CVAC1071_kyUKuIA-output.jpg)
+![Dpad 3 switches placed, solder process](../For_Makers/BuildPics_1.2.2/CVAC1071_kyUKuIA-output.jpg)
 
 Top: Apply a tiny bit of solder to one wing of the contact only.
 
 Left: Using tweezers, hold a switch in place and melt the existing solder to tack it in place. Do all the buttons to this stage, then fit-check their placement using the shell to make sure they are centered under the rubber domes..
 
-![Fit checking dpad](For_Makers/BuildPics_1.2.2/CVAC1074_U2HLUVJ-output.jpg)
+![Fit checking dpad](../For_Makers/BuildPics_1.2.2/CVAC1074_U2HLUVJ-output.jpg)
 
 Right: Tack the opposite corner down using solder, then remelt the first corner and then this corner to eliminate strain.
 
@@ -267,7 +267,7 @@ Bottom: Solder down the rest of the corners.
 
 The buttons should now look like this:
 
-![All dpad buttons](For_Makers/BuildPics_1.2.2/CVAC1072_1oL78HD-output.jpg)
+![All dpad buttons](../For_Makers/BuildPics_1.2.2/CVAC1072_1oL78HD-output.jpg)
 
 Using a multimeter, check continuity between the exposed copper pads that stick out past the button. They should be disconnected when the switch isn't pressed, and shorted when the switch is pressed.
 
@@ -278,47 +278,47 @@ Also see [the PhobGCC Hall Effect Sensor Soldering Video](https://www.youtube.co
 
 The Hall effect sensors come as a small black prism with two beveled edges.
 
-![Straight hall sensor](For_Makers/BuildPics_1.2.2/CVAC1077_yWpEYon-output.jpg)
+![Straight hall sensor](../For_Makers/BuildPics_1.2.2/CVAC1077_yWpEYon-output.jpg)
 
 The legs of the Hall effect sensors must be bent 90 degrees so that the beveled edges face upward, with the bend as close as possible to the head of the sensor.
 
-![Bent hall sensor](For_Makers/BuildPics_1.2.2/CVAC1080_UY7wI4g-output.jpg)
+![Bent hall sensor](../For_Makers/BuildPics_1.2.2/CVAC1080_UY7wI4g-output.jpg)
 
 If the bends are located too far away from the body of the sensor, it will be difficult to get the stickbox in place.
 
 Place the bent sensors in the board with the legs through the holes.
 Make sure they are on the upper side of the board with the text; this is easy to mix up on the C-stick board.
 
-![Hall sensors on C-stick board](For_Makers/BuildPics_1.2.2/CVAC1081_zGE2DdR-output.jpg)
+![Hall sensors on C-stick board](../For_Makers/BuildPics_1.2.2/CVAC1081_zGE2DdR-output.jpg)
 
 On the motherboard, place the Hall sensors on the top and left sides where the pads are small and close together.
 Do not try to spread the Hall sensor legs to fit through the wider-spaced holes on the bottom and right sides; you may break the sensor and it won't work even if you manage to not break them.
 
-![Hall sensors on motherboard](For_Makers/BuildPics_1.2.2/CVAC1088_BGdBDFf-output.jpg)
+![Hall sensors on motherboard](../For_Makers/BuildPics_1.2.2/CVAC1088_BGdBDFf-output.jpg)
 
 Install the stickboxes, already equipped with magnets, on the boards before soldering down the Hall sensors.
 
-![stickbox on c-stick board](For_Makers/BuildPics_1.2.2/CVAC1083_ydmlexH-output.jpg)
+![stickbox on c-stick board](../For_Makers/BuildPics_1.2.2/CVAC1083_ydmlexH-output.jpg)
 
-![stickbox on motherboard](For_Makers/BuildPics_1.2.2/CVAC1090_N3j5WHq-output.jpg)
+![stickbox on motherboard](../For_Makers/BuildPics_1.2.2/CVAC1090_N3j5WHq-output.jpg)
 
 Align the height of the sensors to be roughly the level of this feature in the T3 stickbox or lower, making sure the sensors are centered and level.
 You may need to bend the legs a bit.
 
-![stickbox height reference](For_Makers/BuildPics_1.2.2/CVAC1083_annotated.jpg)
+![stickbox height reference](../For_Makers/BuildPics_1.2.2/CVAC1083_annotated.jpg)
 
 When you are satisfied with the sensor height, solder one leg in place.
 You can then use tweezers to manipulate the position while you remelt that one solder joint in order to fine-tune it.
 
-![one hall leg soldered](For_Makers/BuildPics_1.2.2/CVAC1084_woadHfG-output.jpg)
+![one hall leg soldered](../For_Makers/BuildPics_1.2.2/CVAC1084_woadHfG-output.jpg)
 
 Then, solder the remainder of the legs.
 
-![all hall legs soldered](For_Makers/BuildPics_1.2.2/CVAC1085_28epqhF-output.jpg)
+![all hall legs soldered](../For_Makers/BuildPics_1.2.2/CVAC1085_28epqhF-output.jpg)
 
 Finally, trim the legs.
 
-![c-stick hall legs trimmed](For_Makers/BuildPics_1.2.2/CVAC1087_9D4zsuI-output.jpg)
+![c-stick hall legs trimmed](../For_Makers/BuildPics_1.2.2/CVAC1087_9D4zsuI-output.jpg)
 
 On the motherboard, trim the legs *very closely* and then reflow the solder on each joint.
 They should be no taller than half the height of the screw heads for the stickbox.
@@ -332,7 +332,7 @@ This commonly causes a short-circuit, which does no damage but makes the analog 
 Using SAC305 solder, which is harder, seems to have fewer issues.
 And as mentioned before, make sure that the Hall sensor solder joints are as flat to the board as you can make them, to help mitigate this issue.
 
-![motherboard hall legs trimmed](For_Makers/BuildPics_1.2.2/CVAC1095_b35fEvP-output.jpg)
+![motherboard hall legs trimmed](../For_Makers/BuildPics_1.2.2/CVAC1095_b35fEvP-output.jpg)
 
 ## C-stick Cable Soldering
 
@@ -342,20 +342,20 @@ You can either use the ribbon cable harvested from the OEM board, or you can sol
 
 Since I'm using the OEM cable, I prefer to put the red line on the side with the square pad on the C-stick board.
 
-![Cable in c-stick board](For_Makers/BuildPics_1.2.2/CVAC1096_pR6Srfa-output.jpg)
+![Cable in c-stick board](../For_Makers/BuildPics_1.2.2/CVAC1096_pR6Srfa-output.jpg)
 
 Solder the exposed ends to the pads.
 
-![Cable soldered to c-stick board](For_Makers/BuildPics_1.2.2/CVAC1097_XgsctHq-output.jpg)
+![Cable soldered to c-stick board](../For_Makers/BuildPics_1.2.2/CVAC1097_XgsctHq-output.jpg)
 
 Next, connect the opposite end of either the ribbon cable or the wires to the motherboard.
 Make sure that both boards are facing up, and make sure they are oriented like this to ensure that the connections do not get mixed up.
 
-![Cable connecting c-stick to motherboard](For_Makers/BuildPics_1.2.2/CVAC1100_dQf9AKg-output.jpg)
+![Cable connecting c-stick to motherboard](../For_Makers/BuildPics_1.2.2/CVAC1100_dQf9AKg-output.jpg)
 
 Then, solder the wires to the motherboard.
 
-![C-stick cable soldered to motherboard](For_Makers/BuildPics_1.2.2/CVAC1101_oiRxotI-output.jpg)
+![C-stick cable soldered to motherboard](../For_Makers/BuildPics_1.2.2/CVAC1101_oiRxotI-output.jpg)
 
 ## Controller Cable Soldering
 
@@ -363,11 +363,11 @@ See [this section of the PhobGCC 1.2 Assembly Video](https://www.youtube.com/wat
 
 If you are using an OEM cable harvested from a first-party Gamecube controller, the black wire should be placed farthest from the center of the controller, and the blue wire closest to the center of the controller.
 
-![Controller cable colors](For_Makers/BuildPics_1.2.2/CVAC1106_nKaZ4km-output.jpg)
+![Controller cable colors](../For_Makers/BuildPics_1.2.2/CVAC1106_nKaZ4km-output.jpg)
 
 The pins themselves are actually basketlike sheet metal forms, so when you solder them, they take up a fairly large amount of solder.
 
-![Controller cable soldered](For_Makers/BuildPics_1.2.2/CVAC1107_Khu6BvC-output.jpg)
+![Controller cable soldered](../For_Makers/BuildPics_1.2.2/CVAC1107_Khu6BvC-output.jpg)
 
 ## Trigger Paddle Soldering
 
@@ -379,46 +379,46 @@ Cut and strip wires that are roughly 1 inch long (25mm), and solder them in so t
 
 Do not have the wires exit the front side with the contacts, or they can short to the Hall effect sensor pins.
 
-![Wires soldered into trigger paddles](For_Makers/BuildPics_1.2.2/CVAC1108_AFMbsiO-output.jpg)
+![Wires soldered into trigger paddles](../For_Makers/BuildPics_1.2.2/CVAC1108_AFMbsiO-output.jpg)
 
 Load the trigger paddles with pads exposed into the rumble bracket (whether OEM or third-party), and mount the rumble bracket to the PCB.
 Make sure the wires safely exit the slots and do not get caught or pinched under the bracket.
 
-![Trigger wires in slots of rumble bracket](For_Makers/BuildPics_1.2.2/CVAC1109_6LWiGDH-output.jpg)
+![Trigger wires in slots of rumble bracket](../For_Makers/BuildPics_1.2.2/CVAC1109_6LWiGDH-output.jpg)
 
 Tuck the trigger paddle wires into the nearby holes in the motherboard.
 
-![Trigger wires in holes](For_Makers/BuildPics_1.2.2/CVAC1111_N0bJKZt-output.jpg)
+![Trigger wires in holes](../For_Makers/BuildPics_1.2.2/CVAC1111_N0bJKZt-output.jpg)
 
 Then, being careful not to let them slip out, solder them to the motherboard.
 
-![Trigger wires soldered](For_Makers/BuildPics_1.2.2/CVAC1112_xdrTBOe-output.jpg)
+![Trigger wires soldered](../For_Makers/BuildPics_1.2.2/CVAC1112_xdrTBOe-output.jpg)
 
 ## Rumble Motor Soldering
 
 Next, mount the rumble motor back in the rumble bracket by inserting it into the rectangular box.
 Make sure that the shaft is on the cable side, and the motor is rotated so that the wires are on the D-pad side, close to the edge of the box.
 
-![Rumble motor in place](For_Makers/BuildPics_1.2.2/CVAC1113_9EfRr5r-output.jpg)
+![Rumble motor in place](../For_Makers/BuildPics_1.2.2/CVAC1113_9EfRr5r-output.jpg)
 
 Apply a generous blob of solder to each of the rumble motor pads.
 
-![Rumble motor solder blobs](For_Makers/BuildPics_1.2.2/CVAC1115_Kc7aSfL-output.jpg)
+![Rumble motor solder blobs](../For_Makers/BuildPics_1.2.2/CVAC1115_Kc7aSfL-output.jpg)
 
 To solder the wires down, melt the blob of solder with your soldering iron and use tweezers to hold the wire in the pool.
 Remove the hot soldering iron, and keep the wire still as the solder cools.
 
 Clip the wires into place on the rumble bracket.
 
-![Rumble motor wires soldered](For_Makers/BuildPics_1.2.2/CVAC1116_YjbJXub-output.jpg)
+![Rumble motor wires soldered](../For_Makers/BuildPics_1.2.2/CVAC1116_YjbJXub-output.jpg)
 
 # Completion and next steps
 
-![PhobGCC 1.2.2 complete](For_Makers/BuildPics_1.2.2/CVAC1118_1lwoupq-output.jpg)
+![PhobGCC 1.2.2 complete](../For_Makers/BuildPics_1.2.2/CVAC1118_1lwoupq-output.jpg)
 
-Now that you have completed the soldering steps, follow the [Board Debugging Guide for PhobGCC 1.2](For_Makers/Board_Level_Debugging_1.2.md) to make sure it's ready to go.
+Now that you have completed the soldering steps, follow the [Board Debugging Guide for PhobGCC 1.2](../For_Makers/Board_Level_Debugging_1.2.md) to make sure it's ready to go.
 
-Then, reassemble it, and follow the Initial Steps in the [PhobGCC Calibration Guide](For_Users/Phob_Calibration_Guide_Latest.md) for the version of the software you have flashed on the Teensy.
+Then, reassemble it, and follow the Initial Steps in the [PhobGCC Calibration Guide](../For_Users/Phob_Calibration_Guide_Latest.md) for the version of the software you have flashed on the Teensy.
 
 And, enjoy!
 

--- a/For_Makers/Build_Guide_2.0.md
+++ b/For_Makers/Build_Guide_2.0.md
@@ -4,7 +4,7 @@ This is an illustrated guide to making a PhobGCC 2.0, using photos taken of a Ph
 
 Newer board versions may differ slightly in appearance but this guide will still be applicable.
 
-![Motherboard Overview](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/01_Phob2_Board.jpg?raw=true)
+![Motherboard Overview](For_Makers/BuildPics_2.0.1/01_Phob2_Board.jpg?raw=true)
 
 If you want to see it in motion, watch the **[PhobGCC 2.0 Assembly Video]**.
 
@@ -39,7 +39,7 @@ Come to the [PhobGCC Discord Server](https://discord.gg/yrpUu7mgzm) for advice o
 
 # Parts
 
-Some of the parts are taken from a donor Gamecube controller, while others must be sourced new. Check the [PhobGCC Ordering Guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob2_Ordering_Guide.md) for a list of what you need to purchase.
+Some of the parts are taken from a donor Gamecube controller, while others must be sourced new. Check the [PhobGCC Ordering Guide](For_Makers/Phob2_Ordering_Guide.md) for a list of what you need to purchase.
 
 ## New Parts
 
@@ -72,7 +72,7 @@ Begin by taking apart the donor GCC using a Tri-Wing screwdriver.
 
 Remove the motherboard.
 
-![Donor motherboard](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/05_Phob2_Harvest_Rear.jpg?raw=true)
+![Donor motherboard](For_Makers/BuildPics_2.0.1/05_Phob2_Harvest_Rear.jpg?raw=true)
 
 You will want to remove the following parts from it:
 
@@ -85,12 +85,12 @@ You will want to remove the following parts from it:
 7. Rumble motor (or omit it, or use a cell rumble)
 8. Stick caps
 
-![Parts harvested](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/07_Phob2_Harvest_Parts.jpg?raw=true)
+![Parts harvested](For_Makers/BuildPics_2.0.1/07_Phob2_Harvest_Parts.jpg?raw=true)
 
 If you're not familiar with removing the stickboxes, you can stick the points of tweezers between the stickbox and the potentiometers to unclip the potentiometers.
 Then, use a JIS #0 screwdriver to unscrew the screws from the bottom of the stickboxes.
 
-![Potentiometer unclipping](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/06_Phob2_Harvest_Stickbox.jpg?raw=true)
+![Potentiometer unclipping](For_Makers/BuildPics_2.0.1/06_Phob2_Harvest_Stickbox.jpg?raw=true)
 
 ## Magnet Mounting
 
@@ -109,13 +109,13 @@ Do not allow it to evaporate on its own, or it will simply redeposit the grease 
 Then, I prefer to scratch up the pegs using a steel pick or a razor blade.
 This exposes clean, fresh plastic for gluing to.
 
-![Scratch stickbox pegs](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/08_Phob2_Stickbox_Prep.jpg?raw=true)
+![Scratch stickbox pegs](For_Makers/BuildPics_2.0.1/08_Phob2_Stickbox_Prep.jpg?raw=true)
 
 **Do not apply superglue to the pegs!**
 
 Press-fit the magnet holders over the pegs, making sure that the hole for the magnets is offset downward.
 
-![Stickbox with magnet holders](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/09_Phob2_MagHolders.jpg?raw=true)
+![Stickbox with magnet holders](For_Makers/BuildPics_2.0.1/09_Phob2_MagHolders.jpg?raw=true)
 
 The ideal offset may vary with different magnets, and different magnet/offset combinations may result in slightly different stick behavior.
 
@@ -124,13 +124,13 @@ I prefer thin superglue.
 
 **Be *very sparing* with superglue so you do not contaminate the stickbox!**
 
-![Stickbox with magnet holders](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/10_Phob2_MagnetWell.jpg?raw=true)
+![Stickbox with magnet holders](For_Makers/BuildPics_2.0.1/10_Phob2_MagnetWell.jpg?raw=true)
 
 Insert magnets into the magnet wells, making sure that the magnets are all oriented horizontally.
 
 **If the magnets are not horizontal then the stick will not function.**
 
-![Stickbox with magnets](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/11_Phob2_Magnets.jpg?raw=true)
+![Stickbox with magnets](For_Makers/BuildPics_2.0.1/11_Phob2_Magnets.jpg?raw=true)
 
 If you wish, you can add extra superglue on top of the magnets to ensure they are securely held in place, though this is not absolutely necessary.
 
@@ -144,19 +144,19 @@ First, use a JIS #1 screwdriver to unscrew these four screws from the backshell 
 If you attempt to use a Phillips screwdriver, you are *extremely* likely to damage the screw heads by camming out.
 Please use a JIS screwdriver so that any future modders working on the controller will have an easier time removing them.
 
-![Trigger screws to remove](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/12_Phob2_Back_Overview.jpg?raw=true)
+![Trigger screws to remove](For_Makers/BuildPics_2.0.1/12_Phob2_Back_Overview.jpg?raw=true)
 
 Remove the plate above each trigger and the trigger components, and find this protruding corner on each side.
 
-![Trigger corner](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/13_Phob2_TrigCorner.jpg?raw=true)
+![Trigger corner](For_Makers/BuildPics_2.0.1/13_Phob2_TrigCorner.jpg?raw=true)
 
 Using your flush cutters, remove about 1mm of height from the top of this corner.
 
-![Trigger corner trimmed](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/14_Phob2_CornerCut.jpg?raw=true)
+![Trigger corner trimmed](For_Makers/BuildPics_2.0.1/14_Phob2_CornerCut.jpg?raw=true)
 
 This ensures that the tab on the trigger that moves the trigger potentiometer does not get caught on that corner.
 
-![Trigger corner clearance](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/15_Phob2_CornerClear.jpg?raw=true)
+![Trigger corner clearance](For_Makers/BuildPics_2.0.1/15_Phob2_CornerClear.jpg?raw=true)
 
 ## Soldering Interlude
 
@@ -270,16 +270,16 @@ You will have to remove it.
 To do this, first simply snap it off at the motherboard side.
 You can use your bare hands, but be careful to avoid touching the button contacts, such as for the Start button, or you may contaminate them with oil.
 
-![breaking daughterboard](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/02_Phob2_Break.jpg?raw=true)
+![breaking daughterboard](For_Makers/BuildPics_2.0.1/02_Phob2_Break.jpg?raw=true)
 
 Then, break the two "mousebites" off of the C-Stick daughterboard using pliers.
 Note that one is longer than the other; this is normal.
 
-![breaking mousebites](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/03_Phob2_Mousebites.jpg?raw=true)
+![breaking mousebites](For_Makers/BuildPics_2.0.1/03_Phob2_Mousebites.jpg?raw=true)
 
 This should be the result.
 
-![boards laid out](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/04_Phob2_Separate.jpg?raw=true)
+![boards laid out](For_Makers/BuildPics_2.0.1/04_Phob2_Separate.jpg?raw=true)
 
 ## RP2040 Programming
 
@@ -302,31 +302,31 @@ Also make sure that the switch stands perfectly square to the board, or the boar
 
 If you are using a Z button switch harvested from an original GCC, you can ignore the two large circular holes.
 
-![OEM Z](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/18_Phob2_OEM_Z.jpg?raw=true)
+![OEM Z](For_Makers/BuildPics_2.0.1/18_Phob2_OEM_Z.jpg?raw=true)
 
 If you are using an Omron tactile Z switch as listed in the parts ordering guide, here are the slight tweaks you must make.
 
-![Omron Tactile Z before trimming](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/19_Phob2_TacZ.jpg?raw=true)
+![Omron Tactile Z before trimming](For_Makers/BuildPics_2.0.1/19_Phob2_TacZ.jpg?raw=true)
 
 Firstly, trim the two leads off the top of the button.
 These interfere with a rib on the front shell.
 
-![Omron Tactile Z haircut](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/20_Phob2_TacZHaircut.jpg?raw=true)
+![Omron Tactile Z haircut](For_Makers/BuildPics_2.0.1/20_Phob2_TacZHaircut.jpg?raw=true)
 
 Secondly, when you solder, don't use the U-shaped solder pads at the board edge.
 Instead, the structural legs go through the larger holes farther from the board edge.
 
 Make sure to not overfill the holes for the structural legs; you want the solder to sit entirely below the surface.
 
-![Omron Tactile Z soldered](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/21_Phob2_TacZ_Solder.jpg?raw=true)
+![Omron Tactile Z soldered](For_Makers/BuildPics_2.0.1/21_Phob2_TacZ_Solder.jpg?raw=true)
 
 This is because you will need to trim the structural legs completely flush in order to not interfere with the trigger guards.
 
-![Omron Tactile Z legs trimmed](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/22_Phob2_TacZ_TrimLegs.jpg?raw=true)
+![Omron Tactile Z legs trimmed](For_Makers/BuildPics_2.0.1/22_Phob2_TacZ_TrimLegs.jpg?raw=true)
 
 Additionally, you need to make room for the structural legs on top by trimming the button rubber as follows:
 
-![Tac Z button rubber trim](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/23_Phob2_TacZ_RubberCut.jpg?raw=true)
+![Tac Z button rubber trim](For_Makers/BuildPics_2.0.1/23_Phob2_TacZ_RubberCut.jpg?raw=true)
 
 As a note for later, it may take a little more force than you may be used to when inserting the motherboard into the front shell when you use an Omron tactile Z switch.
 
@@ -336,13 +336,13 @@ This is normal, and does not cause any issues.
 
 Mount the trigger potentiometers to the back of the board. Do not mount them to the front side with all of the chips.
 
-![Trigger potentiometers soldered](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/25_Phob2_TriggerPot_Solder.jpg?raw=true)
+![Trigger potentiometers soldered](For_Makers/BuildPics_2.0.1/25_Phob2_TriggerPot_Solder.jpg?raw=true)
 
 To secure them when soldering, you can tape them to the board with masking tape, or just rest the board on top of the potentiometers.
 
 Be sure to check after soldering your first joint that the potentiometer is laying flat against the back of the board before continuing.
 
-![Trigger potentiometers taped](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/24_Phob2_TriggerPots.jpg?raw=true)
+![Trigger potentiometers taped](For_Makers/BuildPics_2.0.1/24_Phob2_TriggerPots.jpg?raw=true)
 
 ## Trigger Paddle Soldering
 
@@ -356,11 +356,11 @@ Apply flux to the ends of the wires, making sure not to cause them to fray if us
 
 Hold the trigger paddles in a vise and apply solder to fill the through-hole pads with solder.
 
-![Trigger paddle solder](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/16_Phob2_Paddles.jpg?raw=true)
+![Trigger paddle solder](For_Makers/BuildPics_2.0.1/16_Phob2_Paddles.jpg?raw=true)
 
 Then, heat the front side of each through-hole with your soldering iron to melt it, and insert the fluxed end of the wire from the back side of the hole where the silkscreen markings are.
 
-![Trigger paddle wires](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/17_Phob2_PaddleWires.jpg?raw=true)
+![Trigger paddle wires](For_Makers/BuildPics_2.0.1/17_Phob2_PaddleWires.jpg?raw=true)
 
 ## C-stick Cable Soldering
 
@@ -376,11 +376,11 @@ Then, I used the same technique as in the Trigger Paddle Soldering section to in
 
 Note that this is the side with silkscreen around the through-holes.
 
-![C-stick soldering](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/26_Phob2_Cstick_Solder.jpg?raw=true)
+![C-stick soldering](For_Makers/BuildPics_2.0.1/26_Phob2_Cstick_Solder.jpg?raw=true)
 
 For these especially, if you are using individual wires I strongly recommend that you make their lengths as consistent as possible, and solder them such that the insulation ends at the same distance from the C-stick daughterboard.
 
-![C-stick wires](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/27_Phob2_Cstick_Wires.jpg?raw=true)
+![C-stick wires](For_Makers/BuildPics_2.0.1/27_Phob2_Cstick_Wires.jpg?raw=true)
 
 The uniform length helps when you are inserting the wires into the motherboard.
 
@@ -388,23 +388,23 @@ Support the motherboard above the C-Stick daughterboard with the daughterboard o
 
 If you flip it around, the C-stick will not function at all.
 
-![C-stick alignmnt](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/28_Phob2_Cstick_Align.jpg?raw=true)
+![C-stick alignmnt](For_Makers/BuildPics_2.0.1/28_Phob2_Cstick_Align.jpg?raw=true)
 
 Insert all of the C-Stick wires into the motherboard.
 
 Make sure that all of the wires are straight and none of them are crossed, or the C-Stick will not function.
 
-![C-stick wire insertion into the motherboard](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/29_Phob2_Cstick_InsertWires.jpg?raw=true)
+![C-stick wire insertion into the motherboard](For_Makers/BuildPics_2.0.1/29_Phob2_Cstick_InsertWires.jpg?raw=true)
 
 Then solder the wires.
 
-![C-stick wire soldering to the motherboard](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/30_Phob2_Cstick_WireSolder.jpg?raw=true)
+![C-stick wire soldering to the motherboard](For_Makers/BuildPics_2.0.1/30_Phob2_Cstick_WireSolder.jpg?raw=true)
 
 ## Stickbox Installation
 
 Install the stickboxes on the motherboard and the C-Stick.
 
-![Stickbox on motherboard](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/31_Phob2_StickboxInstall.jpg?raw=true)
+![Stickbox on motherboard](For_Makers/BuildPics_2.0.1/31_Phob2_StickboxInstall.jpg?raw=true)
 
 You must have the magnets mounted above the 3-legged SMD Hall-Effect sensors.
 
@@ -423,11 +423,11 @@ Tuck the wires from the trigger paddles into their respective holes on the mothe
 
 For R, make sure not to mix up the holes with the extra holes for mouseswitch Z, which are nearby.
 
-![Rumble bracket on back of motherboard](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/32_Phob2_RumbleBracket.jpg?raw=true)
+![Rumble bracket on back of motherboard](For_Makers/BuildPics_2.0.1/32_Phob2_RumbleBracket.jpg?raw=true)
 
 Then solder the wires in place.
 
-![Trigger wires soldered](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/33_Phob2_TriggerWires.jpg?raw=true)
+![Trigger wires soldered](For_Makers/BuildPics_2.0.1/33_Phob2_TriggerWires.jpg?raw=true)
 
 ## Controller Cable Soldering
 
@@ -437,11 +437,11 @@ The cable must go in the back of the motherboard.
 
 If you are using an OEM cable harvested from a first-party Gamecube controller, the black wire should be placed farthest from the center of the controller, and the blue wire closest to the center of the controller.
 
-![Cable installation with colors labeled](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/34_Phob2_CableInstall.jpg?raw=true)
+![Cable installation with colors labeled](For_Makers/BuildPics_2.0.1/34_Phob2_CableInstall.jpg?raw=true)
 
 Secure the wire in place, then solder the pins to the pads on the top of the motherboard.
 
-![Cable installation with colors labeled](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/35_Phob2_CableSolder.jpg?raw=true)
+![Cable installation with colors labeled](For_Makers/BuildPics_2.0.1/35_Phob2_CableSolder.jpg?raw=true)
 
 ## OPTIONAL PhobVision installation and soldering
 
@@ -456,13 +456,13 @@ Nonetheless, this guide shows you how to do it so that it fits around the OEM ru
 
 Begin by taking the backshell and marking a point 0.5 inches or 13 mm down directly below the edge, aligned with the center of this tab.
 
-![Marked drill hole](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/36_PhobVision_Mark.jpg?raw=true)
+![Marked drill hole](For_Makers/BuildPics_2.0.1/36_PhobVision_Mark.jpg?raw=true)
 
 Using a *split-point drill bit* to help prevent the bit from wandering around, drill a 7mm diameter hole in the back of the controller.
 
 You may also use a 9/32" bit or a Letter J drill bit.
 
-![PhobVision hole drilled](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/37_PhobVision_Drill.jpg?raw=true)
+![PhobVision hole drilled](For_Makers/BuildPics_2.0.1/37_PhobVision_Drill.jpg?raw=true)
 
 Note that on this particular shell, the bit wandered slightly towards the centerline of the controller, which is fine.
 
@@ -470,25 +470,25 @@ If the bit wanders towards the side of the controller, you may need to carve out
 
 In this case, the hole instead intersects a rib that only exists on T3 shells that you should remove in the vicinity of the hole.
 
-![Rib interference with hole](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/38_PhobVision_Rib.jpg?raw=true)
+![Rib interference with hole](For_Makers/BuildPics_2.0.1/38_PhobVision_Rib.jpg?raw=true)
 
 Simply cut the rib off with flush cutters.
 
-![Rib cut near hole](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/39_PhobVision_CutRib.jpg?raw=true)
+![Rib cut near hole](For_Makers/BuildPics_2.0.1/39_PhobVision_CutRib.jpg?raw=true)
 
 Next up we must prepare the 3.5mm TRRS jack for installation.
 
-![Untouched jack](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/40_PhobVision_Jack.jpg?raw=true)
+![Untouched jack](For_Makers/BuildPics_2.0.1/40_PhobVision_Jack.jpg?raw=true)
 
 To get the jack to fit with an OEM rumble motor, use pliers to bend the tabs on the end sideways.
 
 Note which tabs are used for what.
 
-![Jack with bent tabs, labeled](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/41_PhobVision_Bend.jpg?raw=true)
+![Jack with bent tabs, labeled](For_Makers/BuildPics_2.0.1/41_PhobVision_Bend.jpg?raw=true)
 
 Apply flux to the two bent silver tabs and tin them generously with solder.
 
-![Tinned tabs on jack](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/42_PhobVision_Tin.jpg?raw=true)
+![Tinned tabs on jack](For_Makers/BuildPics_2.0.1/42_PhobVision_Tin.jpg?raw=true)
 
 Cut a two-pin JST-PH pigtail's wires to 3 inches long (75mm), strip the ends, and apply flux.
 Shorter wires give less slack when maneuvering, and longer wires are hard to fit, so be fairly precise with the length here.
@@ -497,17 +497,17 @@ Then solder them to the two tinned tabs.
 
 Make sure that the black wire goes to the middle tab, and the red wire goes to the other silver tab.
 
-![Wires soldered to jack](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/43_PhobVision_Solder.jpg?raw=true)
+![Wires soldered to jack](For_Makers/BuildPics_2.0.1/43_PhobVision_Solder.jpg?raw=true)
 
 Make sure the wires are soldered to the back side of the tabs so that they do not stick out past the end.
 
-![Wires do not protrude past the end of jack](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/44_PhobVision_Flat.jpg?raw=true)
+![Wires do not protrude past the end of jack](For_Makers/BuildPics_2.0.1/44_PhobVision_Flat.jpg?raw=true)
 
 Generously apply hot glue between the wires and the barrel of the TRRS jack in order to provide strain relief.
 
 Again, do not let it protrude much past the end of the jack.
 
-![Hot glue used as strain relief](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/45_PhobVision_Glue.jpg?raw=true)
+![Hot glue used as strain relief](For_Makers/BuildPics_2.0.1/45_PhobVision_Glue.jpg?raw=true)
 
 Next, cut 1.25" (32mm) long wires, strip both ends, and apply flux.
 Shorter wires might not reach, and longer can interfere with closing the controller, so be precise with the length here.
@@ -517,11 +517,11 @@ You must leave the connector in the receptacle while soldering, or else the pins
 
 Make sure to match red with red and black with black; I used the scrap ends of the pigtail wires for this so the colors match nicely.
 
-![JST receptacle soldered](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/46_PhobVision_JST_Solder.jpg?raw=true)
+![JST receptacle soldered](For_Makers/BuildPics_2.0.1/46_PhobVision_JST_Solder.jpg?raw=true)
 
 Insert the receptacle's wires into the back of the motherboard at the J2 through-hole pads, and solder them on the front of the motherboard.
 
-![JST soldered to phobvision pads](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/47_PhobVision_Mobo_Solder.jpg?raw=true)
+![JST soldered to phobvision pads](For_Makers/BuildPics_2.0.1/47_PhobVision_Mobo_Solder.jpg?raw=true)
 
 At this point, if you are installing rumble, mount the rumble motor in the rumble bracket by inserting it into the rectangular box.
 Make sure that the shaft is on the cable side, and the motor is rotated so that the wires are on the D-pad side, close to the edge of the box.
@@ -532,15 +532,15 @@ Tuck the rumble wires in the clip on the rumble bracket.
 
 Then hot glue the PhobVision JST receptacle to the rumble bracket like depicted, ensuring that the opening is not blocked by the glue.
 
-![JST glued to rumble bracket](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/48_PhobVision_JST_Glue.jpg?raw=true)
+![JST glued to rumble bracket](For_Makers/BuildPics_2.0.1/48_PhobVision_JST_Glue.jpg?raw=true)
 
 Next, install the TRRS jack in the backshell and install the nut on the outside using pliers.
 
 I recommend you orient the jack so that the wires initially go towards the center of the controller, then loop around towards the triggers.
 
-![Jack in the backshell with suggested wire orientation](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/49_PhobVision_Jack_Install.jpg?raw=true)
+![Jack in the backshell with suggested wire orientation](For_Makers/BuildPics_2.0.1/49_PhobVision_Jack_Install.jpg?raw=true)
 
-![Nut holding the jack in place](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/50_PhobVision_Nut.jpg?raw=true)
+![Nut holding the jack in place](For_Makers/BuildPics_2.0.1/50_PhobVision_Nut.jpg?raw=true)
 
 ## Rumble Motor Soldering
 
@@ -551,11 +551,11 @@ Make sure that the shaft is on the cable side, and the motor is rotated so that 
 
 Now your PhobGCC should be complete!
 
-![Front of PhobGCC 2](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/Phob2_Front.jpg?raw=true)
+![Front of PhobGCC 2](For_Makers/BuildPics_2.0.1/Phob2_Front.jpg?raw=true)
 
-![Rear of PhobGCC 2](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/Phob2_Back.jpg?raw=true)
+![Rear of PhobGCC 2](For_Makers/BuildPics_2.0.1/Phob2_Back.jpg?raw=true)
 
-Reassemble your controller, and follow the Initial Setup procedure in the [PhobGCC Calibration Guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_Latest.md) for the version of the software you have flashed on the RP2040.
+Reassemble your controller, and follow the Initial Setup procedure in the [PhobGCC Calibration Guide](For_Users/Phob_Calibration_Guide_Latest.md) for the version of the software you have flashed on the RP2040.
 
 And, enjoy!
 

--- a/For_Makers/Build_Guide_2.0.md
+++ b/For_Makers/Build_Guide_2.0.md
@@ -4,7 +4,7 @@ This is an illustrated guide to making a PhobGCC 2.0, using photos taken of a Ph
 
 Newer board versions may differ slightly in appearance but this guide will still be applicable.
 
-![Motherboard Overview](For_Makers/BuildPics_2.0.1/01_Phob2_Board.jpg?raw=true)
+![Motherboard Overview](For_Makers/BuildPics_2.0.1/01_Phob2_Board.jpg)
 
 If you want to see it in motion, watch the **[PhobGCC 2.0 Assembly Video]**.
 
@@ -72,7 +72,7 @@ Begin by taking apart the donor GCC using a Tri-Wing screwdriver.
 
 Remove the motherboard.
 
-![Donor motherboard](For_Makers/BuildPics_2.0.1/05_Phob2_Harvest_Rear.jpg?raw=true)
+![Donor motherboard](For_Makers/BuildPics_2.0.1/05_Phob2_Harvest_Rear.jpg)
 
 You will want to remove the following parts from it:
 
@@ -85,12 +85,12 @@ You will want to remove the following parts from it:
 7. Rumble motor (or omit it, or use a cell rumble)
 8. Stick caps
 
-![Parts harvested](For_Makers/BuildPics_2.0.1/07_Phob2_Harvest_Parts.jpg?raw=true)
+![Parts harvested](For_Makers/BuildPics_2.0.1/07_Phob2_Harvest_Parts.jpg)
 
 If you're not familiar with removing the stickboxes, you can stick the points of tweezers between the stickbox and the potentiometers to unclip the potentiometers.
 Then, use a JIS #0 screwdriver to unscrew the screws from the bottom of the stickboxes.
 
-![Potentiometer unclipping](For_Makers/BuildPics_2.0.1/06_Phob2_Harvest_Stickbox.jpg?raw=true)
+![Potentiometer unclipping](For_Makers/BuildPics_2.0.1/06_Phob2_Harvest_Stickbox.jpg)
 
 ## Magnet Mounting
 
@@ -109,13 +109,13 @@ Do not allow it to evaporate on its own, or it will simply redeposit the grease 
 Then, I prefer to scratch up the pegs using a steel pick or a razor blade.
 This exposes clean, fresh plastic for gluing to.
 
-![Scratch stickbox pegs](For_Makers/BuildPics_2.0.1/08_Phob2_Stickbox_Prep.jpg?raw=true)
+![Scratch stickbox pegs](For_Makers/BuildPics_2.0.1/08_Phob2_Stickbox_Prep.jpg)
 
 **Do not apply superglue to the pegs!**
 
 Press-fit the magnet holders over the pegs, making sure that the hole for the magnets is offset downward.
 
-![Stickbox with magnet holders](For_Makers/BuildPics_2.0.1/09_Phob2_MagHolders.jpg?raw=true)
+![Stickbox with magnet holders](For_Makers/BuildPics_2.0.1/09_Phob2_MagHolders.jpg)
 
 The ideal offset may vary with different magnets, and different magnet/offset combinations may result in slightly different stick behavior.
 
@@ -124,13 +124,13 @@ I prefer thin superglue.
 
 **Be *very sparing* with superglue so you do not contaminate the stickbox!**
 
-![Stickbox with magnet holders](For_Makers/BuildPics_2.0.1/10_Phob2_MagnetWell.jpg?raw=true)
+![Stickbox with magnet holders](For_Makers/BuildPics_2.0.1/10_Phob2_MagnetWell.jpg)
 
 Insert magnets into the magnet wells, making sure that the magnets are all oriented horizontally.
 
 **If the magnets are not horizontal then the stick will not function.**
 
-![Stickbox with magnets](For_Makers/BuildPics_2.0.1/11_Phob2_Magnets.jpg?raw=true)
+![Stickbox with magnets](For_Makers/BuildPics_2.0.1/11_Phob2_Magnets.jpg)
 
 If you wish, you can add extra superglue on top of the magnets to ensure they are securely held in place, though this is not absolutely necessary.
 
@@ -144,19 +144,19 @@ First, use a JIS #1 screwdriver to unscrew these four screws from the backshell 
 If you attempt to use a Phillips screwdriver, you are *extremely* likely to damage the screw heads by camming out.
 Please use a JIS screwdriver so that any future modders working on the controller will have an easier time removing them.
 
-![Trigger screws to remove](For_Makers/BuildPics_2.0.1/12_Phob2_Back_Overview.jpg?raw=true)
+![Trigger screws to remove](For_Makers/BuildPics_2.0.1/12_Phob2_Back_Overview.jpg)
 
 Remove the plate above each trigger and the trigger components, and find this protruding corner on each side.
 
-![Trigger corner](For_Makers/BuildPics_2.0.1/13_Phob2_TrigCorner.jpg?raw=true)
+![Trigger corner](For_Makers/BuildPics_2.0.1/13_Phob2_TrigCorner.jpg)
 
 Using your flush cutters, remove about 1mm of height from the top of this corner.
 
-![Trigger corner trimmed](For_Makers/BuildPics_2.0.1/14_Phob2_CornerCut.jpg?raw=true)
+![Trigger corner trimmed](For_Makers/BuildPics_2.0.1/14_Phob2_CornerCut.jpg)
 
 This ensures that the tab on the trigger that moves the trigger potentiometer does not get caught on that corner.
 
-![Trigger corner clearance](For_Makers/BuildPics_2.0.1/15_Phob2_CornerClear.jpg?raw=true)
+![Trigger corner clearance](For_Makers/BuildPics_2.0.1/15_Phob2_CornerClear.jpg)
 
 ## Soldering Interlude
 
@@ -270,16 +270,16 @@ You will have to remove it.
 To do this, first simply snap it off at the motherboard side.
 You can use your bare hands, but be careful to avoid touching the button contacts, such as for the Start button, or you may contaminate them with oil.
 
-![breaking daughterboard](For_Makers/BuildPics_2.0.1/02_Phob2_Break.jpg?raw=true)
+![breaking daughterboard](For_Makers/BuildPics_2.0.1/02_Phob2_Break.jpg)
 
 Then, break the two "mousebites" off of the C-Stick daughterboard using pliers.
 Note that one is longer than the other; this is normal.
 
-![breaking mousebites](For_Makers/BuildPics_2.0.1/03_Phob2_Mousebites.jpg?raw=true)
+![breaking mousebites](For_Makers/BuildPics_2.0.1/03_Phob2_Mousebites.jpg)
 
 This should be the result.
 
-![boards laid out](For_Makers/BuildPics_2.0.1/04_Phob2_Separate.jpg?raw=true)
+![boards laid out](For_Makers/BuildPics_2.0.1/04_Phob2_Separate.jpg)
 
 ## RP2040 Programming
 
@@ -302,31 +302,31 @@ Also make sure that the switch stands perfectly square to the board, or the boar
 
 If you are using a Z button switch harvested from an original GCC, you can ignore the two large circular holes.
 
-![OEM Z](For_Makers/BuildPics_2.0.1/18_Phob2_OEM_Z.jpg?raw=true)
+![OEM Z](For_Makers/BuildPics_2.0.1/18_Phob2_OEM_Z.jpg)
 
 If you are using an Omron tactile Z switch as listed in the parts ordering guide, here are the slight tweaks you must make.
 
-![Omron Tactile Z before trimming](For_Makers/BuildPics_2.0.1/19_Phob2_TacZ.jpg?raw=true)
+![Omron Tactile Z before trimming](For_Makers/BuildPics_2.0.1/19_Phob2_TacZ.jpg)
 
 Firstly, trim the two leads off the top of the button.
 These interfere with a rib on the front shell.
 
-![Omron Tactile Z haircut](For_Makers/BuildPics_2.0.1/20_Phob2_TacZHaircut.jpg?raw=true)
+![Omron Tactile Z haircut](For_Makers/BuildPics_2.0.1/20_Phob2_TacZHaircut.jpg)
 
 Secondly, when you solder, don't use the U-shaped solder pads at the board edge.
 Instead, the structural legs go through the larger holes farther from the board edge.
 
 Make sure to not overfill the holes for the structural legs; you want the solder to sit entirely below the surface.
 
-![Omron Tactile Z soldered](For_Makers/BuildPics_2.0.1/21_Phob2_TacZ_Solder.jpg?raw=true)
+![Omron Tactile Z soldered](For_Makers/BuildPics_2.0.1/21_Phob2_TacZ_Solder.jpg)
 
 This is because you will need to trim the structural legs completely flush in order to not interfere with the trigger guards.
 
-![Omron Tactile Z legs trimmed](For_Makers/BuildPics_2.0.1/22_Phob2_TacZ_TrimLegs.jpg?raw=true)
+![Omron Tactile Z legs trimmed](For_Makers/BuildPics_2.0.1/22_Phob2_TacZ_TrimLegs.jpg)
 
 Additionally, you need to make room for the structural legs on top by trimming the button rubber as follows:
 
-![Tac Z button rubber trim](For_Makers/BuildPics_2.0.1/23_Phob2_TacZ_RubberCut.jpg?raw=true)
+![Tac Z button rubber trim](For_Makers/BuildPics_2.0.1/23_Phob2_TacZ_RubberCut.jpg)
 
 As a note for later, it may take a little more force than you may be used to when inserting the motherboard into the front shell when you use an Omron tactile Z switch.
 
@@ -336,13 +336,13 @@ This is normal, and does not cause any issues.
 
 Mount the trigger potentiometers to the back of the board. Do not mount them to the front side with all of the chips.
 
-![Trigger potentiometers soldered](For_Makers/BuildPics_2.0.1/25_Phob2_TriggerPot_Solder.jpg?raw=true)
+![Trigger potentiometers soldered](For_Makers/BuildPics_2.0.1/25_Phob2_TriggerPot_Solder.jpg)
 
 To secure them when soldering, you can tape them to the board with masking tape, or just rest the board on top of the potentiometers.
 
 Be sure to check after soldering your first joint that the potentiometer is laying flat against the back of the board before continuing.
 
-![Trigger potentiometers taped](For_Makers/BuildPics_2.0.1/24_Phob2_TriggerPots.jpg?raw=true)
+![Trigger potentiometers taped](For_Makers/BuildPics_2.0.1/24_Phob2_TriggerPots.jpg)
 
 ## Trigger Paddle Soldering
 
@@ -356,11 +356,11 @@ Apply flux to the ends of the wires, making sure not to cause them to fray if us
 
 Hold the trigger paddles in a vise and apply solder to fill the through-hole pads with solder.
 
-![Trigger paddle solder](For_Makers/BuildPics_2.0.1/16_Phob2_Paddles.jpg?raw=true)
+![Trigger paddle solder](For_Makers/BuildPics_2.0.1/16_Phob2_Paddles.jpg)
 
 Then, heat the front side of each through-hole with your soldering iron to melt it, and insert the fluxed end of the wire from the back side of the hole where the silkscreen markings are.
 
-![Trigger paddle wires](For_Makers/BuildPics_2.0.1/17_Phob2_PaddleWires.jpg?raw=true)
+![Trigger paddle wires](For_Makers/BuildPics_2.0.1/17_Phob2_PaddleWires.jpg)
 
 ## C-stick Cable Soldering
 
@@ -376,11 +376,11 @@ Then, I used the same technique as in the Trigger Paddle Soldering section to in
 
 Note that this is the side with silkscreen around the through-holes.
 
-![C-stick soldering](For_Makers/BuildPics_2.0.1/26_Phob2_Cstick_Solder.jpg?raw=true)
+![C-stick soldering](For_Makers/BuildPics_2.0.1/26_Phob2_Cstick_Solder.jpg)
 
 For these especially, if you are using individual wires I strongly recommend that you make their lengths as consistent as possible, and solder them such that the insulation ends at the same distance from the C-stick daughterboard.
 
-![C-stick wires](For_Makers/BuildPics_2.0.1/27_Phob2_Cstick_Wires.jpg?raw=true)
+![C-stick wires](For_Makers/BuildPics_2.0.1/27_Phob2_Cstick_Wires.jpg)
 
 The uniform length helps when you are inserting the wires into the motherboard.
 
@@ -388,23 +388,23 @@ Support the motherboard above the C-Stick daughterboard with the daughterboard o
 
 If you flip it around, the C-stick will not function at all.
 
-![C-stick alignmnt](For_Makers/BuildPics_2.0.1/28_Phob2_Cstick_Align.jpg?raw=true)
+![C-stick alignmnt](For_Makers/BuildPics_2.0.1/28_Phob2_Cstick_Align.jpg)
 
 Insert all of the C-Stick wires into the motherboard.
 
 Make sure that all of the wires are straight and none of them are crossed, or the C-Stick will not function.
 
-![C-stick wire insertion into the motherboard](For_Makers/BuildPics_2.0.1/29_Phob2_Cstick_InsertWires.jpg?raw=true)
+![C-stick wire insertion into the motherboard](For_Makers/BuildPics_2.0.1/29_Phob2_Cstick_InsertWires.jpg)
 
 Then solder the wires.
 
-![C-stick wire soldering to the motherboard](For_Makers/BuildPics_2.0.1/30_Phob2_Cstick_WireSolder.jpg?raw=true)
+![C-stick wire soldering to the motherboard](For_Makers/BuildPics_2.0.1/30_Phob2_Cstick_WireSolder.jpg)
 
 ## Stickbox Installation
 
 Install the stickboxes on the motherboard and the C-Stick.
 
-![Stickbox on motherboard](For_Makers/BuildPics_2.0.1/31_Phob2_StickboxInstall.jpg?raw=true)
+![Stickbox on motherboard](For_Makers/BuildPics_2.0.1/31_Phob2_StickboxInstall.jpg)
 
 You must have the magnets mounted above the 3-legged SMD Hall-Effect sensors.
 
@@ -423,11 +423,11 @@ Tuck the wires from the trigger paddles into their respective holes on the mothe
 
 For R, make sure not to mix up the holes with the extra holes for mouseswitch Z, which are nearby.
 
-![Rumble bracket on back of motherboard](For_Makers/BuildPics_2.0.1/32_Phob2_RumbleBracket.jpg?raw=true)
+![Rumble bracket on back of motherboard](For_Makers/BuildPics_2.0.1/32_Phob2_RumbleBracket.jpg)
 
 Then solder the wires in place.
 
-![Trigger wires soldered](For_Makers/BuildPics_2.0.1/33_Phob2_TriggerWires.jpg?raw=true)
+![Trigger wires soldered](For_Makers/BuildPics_2.0.1/33_Phob2_TriggerWires.jpg)
 
 ## Controller Cable Soldering
 
@@ -437,11 +437,11 @@ The cable must go in the back of the motherboard.
 
 If you are using an OEM cable harvested from a first-party Gamecube controller, the black wire should be placed farthest from the center of the controller, and the blue wire closest to the center of the controller.
 
-![Cable installation with colors labeled](For_Makers/BuildPics_2.0.1/34_Phob2_CableInstall.jpg?raw=true)
+![Cable installation with colors labeled](For_Makers/BuildPics_2.0.1/34_Phob2_CableInstall.jpg)
 
 Secure the wire in place, then solder the pins to the pads on the top of the motherboard.
 
-![Cable installation with colors labeled](For_Makers/BuildPics_2.0.1/35_Phob2_CableSolder.jpg?raw=true)
+![Cable installation with colors labeled](For_Makers/BuildPics_2.0.1/35_Phob2_CableSolder.jpg)
 
 ## OPTIONAL PhobVision installation and soldering
 
@@ -456,13 +456,13 @@ Nonetheless, this guide shows you how to do it so that it fits around the OEM ru
 
 Begin by taking the backshell and marking a point 0.5 inches or 13 mm down directly below the edge, aligned with the center of this tab.
 
-![Marked drill hole](For_Makers/BuildPics_2.0.1/36_PhobVision_Mark.jpg?raw=true)
+![Marked drill hole](For_Makers/BuildPics_2.0.1/36_PhobVision_Mark.jpg)
 
 Using a *split-point drill bit* to help prevent the bit from wandering around, drill a 7mm diameter hole in the back of the controller.
 
 You may also use a 9/32" bit or a Letter J drill bit.
 
-![PhobVision hole drilled](For_Makers/BuildPics_2.0.1/37_PhobVision_Drill.jpg?raw=true)
+![PhobVision hole drilled](For_Makers/BuildPics_2.0.1/37_PhobVision_Drill.jpg)
 
 Note that on this particular shell, the bit wandered slightly towards the centerline of the controller, which is fine.
 
@@ -470,25 +470,25 @@ If the bit wanders towards the side of the controller, you may need to carve out
 
 In this case, the hole instead intersects a rib that only exists on T3 shells that you should remove in the vicinity of the hole.
 
-![Rib interference with hole](For_Makers/BuildPics_2.0.1/38_PhobVision_Rib.jpg?raw=true)
+![Rib interference with hole](For_Makers/BuildPics_2.0.1/38_PhobVision_Rib.jpg)
 
 Simply cut the rib off with flush cutters.
 
-![Rib cut near hole](For_Makers/BuildPics_2.0.1/39_PhobVision_CutRib.jpg?raw=true)
+![Rib cut near hole](For_Makers/BuildPics_2.0.1/39_PhobVision_CutRib.jpg)
 
 Next up we must prepare the 3.5mm TRRS jack for installation.
 
-![Untouched jack](For_Makers/BuildPics_2.0.1/40_PhobVision_Jack.jpg?raw=true)
+![Untouched jack](For_Makers/BuildPics_2.0.1/40_PhobVision_Jack.jpg)
 
 To get the jack to fit with an OEM rumble motor, use pliers to bend the tabs on the end sideways.
 
 Note which tabs are used for what.
 
-![Jack with bent tabs, labeled](For_Makers/BuildPics_2.0.1/41_PhobVision_Bend.jpg?raw=true)
+![Jack with bent tabs, labeled](For_Makers/BuildPics_2.0.1/41_PhobVision_Bend.jpg)
 
 Apply flux to the two bent silver tabs and tin them generously with solder.
 
-![Tinned tabs on jack](For_Makers/BuildPics_2.0.1/42_PhobVision_Tin.jpg?raw=true)
+![Tinned tabs on jack](For_Makers/BuildPics_2.0.1/42_PhobVision_Tin.jpg)
 
 Cut a two-pin JST-PH pigtail's wires to 3 inches long (75mm), strip the ends, and apply flux.
 Shorter wires give less slack when maneuvering, and longer wires are hard to fit, so be fairly precise with the length here.
@@ -497,17 +497,17 @@ Then solder them to the two tinned tabs.
 
 Make sure that the black wire goes to the middle tab, and the red wire goes to the other silver tab.
 
-![Wires soldered to jack](For_Makers/BuildPics_2.0.1/43_PhobVision_Solder.jpg?raw=true)
+![Wires soldered to jack](For_Makers/BuildPics_2.0.1/43_PhobVision_Solder.jpg)
 
 Make sure the wires are soldered to the back side of the tabs so that they do not stick out past the end.
 
-![Wires do not protrude past the end of jack](For_Makers/BuildPics_2.0.1/44_PhobVision_Flat.jpg?raw=true)
+![Wires do not protrude past the end of jack](For_Makers/BuildPics_2.0.1/44_PhobVision_Flat.jpg)
 
 Generously apply hot glue between the wires and the barrel of the TRRS jack in order to provide strain relief.
 
 Again, do not let it protrude much past the end of the jack.
 
-![Hot glue used as strain relief](For_Makers/BuildPics_2.0.1/45_PhobVision_Glue.jpg?raw=true)
+![Hot glue used as strain relief](For_Makers/BuildPics_2.0.1/45_PhobVision_Glue.jpg)
 
 Next, cut 1.25" (32mm) long wires, strip both ends, and apply flux.
 Shorter wires might not reach, and longer can interfere with closing the controller, so be precise with the length here.
@@ -517,11 +517,11 @@ You must leave the connector in the receptacle while soldering, or else the pins
 
 Make sure to match red with red and black with black; I used the scrap ends of the pigtail wires for this so the colors match nicely.
 
-![JST receptacle soldered](For_Makers/BuildPics_2.0.1/46_PhobVision_JST_Solder.jpg?raw=true)
+![JST receptacle soldered](For_Makers/BuildPics_2.0.1/46_PhobVision_JST_Solder.jpg)
 
 Insert the receptacle's wires into the back of the motherboard at the J2 through-hole pads, and solder them on the front of the motherboard.
 
-![JST soldered to phobvision pads](For_Makers/BuildPics_2.0.1/47_PhobVision_Mobo_Solder.jpg?raw=true)
+![JST soldered to phobvision pads](For_Makers/BuildPics_2.0.1/47_PhobVision_Mobo_Solder.jpg)
 
 At this point, if you are installing rumble, mount the rumble motor in the rumble bracket by inserting it into the rectangular box.
 Make sure that the shaft is on the cable side, and the motor is rotated so that the wires are on the D-pad side, close to the edge of the box.
@@ -532,15 +532,15 @@ Tuck the rumble wires in the clip on the rumble bracket.
 
 Then hot glue the PhobVision JST receptacle to the rumble bracket like depicted, ensuring that the opening is not blocked by the glue.
 
-![JST glued to rumble bracket](For_Makers/BuildPics_2.0.1/48_PhobVision_JST_Glue.jpg?raw=true)
+![JST glued to rumble bracket](For_Makers/BuildPics_2.0.1/48_PhobVision_JST_Glue.jpg)
 
 Next, install the TRRS jack in the backshell and install the nut on the outside using pliers.
 
 I recommend you orient the jack so that the wires initially go towards the center of the controller, then loop around towards the triggers.
 
-![Jack in the backshell with suggested wire orientation](For_Makers/BuildPics_2.0.1/49_PhobVision_Jack_Install.jpg?raw=true)
+![Jack in the backshell with suggested wire orientation](For_Makers/BuildPics_2.0.1/49_PhobVision_Jack_Install.jpg)
 
-![Nut holding the jack in place](For_Makers/BuildPics_2.0.1/50_PhobVision_Nut.jpg?raw=true)
+![Nut holding the jack in place](For_Makers/BuildPics_2.0.1/50_PhobVision_Nut.jpg)
 
 ## Rumble Motor Soldering
 
@@ -551,9 +551,9 @@ Make sure that the shaft is on the cable side, and the motor is rotated so that 
 
 Now your PhobGCC should be complete!
 
-![Front of PhobGCC 2](For_Makers/BuildPics_2.0.1/Phob2_Front.jpg?raw=true)
+![Front of PhobGCC 2](For_Makers/BuildPics_2.0.1/Phob2_Front.jpg)
 
-![Rear of PhobGCC 2](For_Makers/BuildPics_2.0.1/Phob2_Back.jpg?raw=true)
+![Rear of PhobGCC 2](For_Makers/BuildPics_2.0.1/Phob2_Back.jpg)
 
 Reassemble your controller, and follow the Initial Setup procedure in the [PhobGCC Calibration Guide](For_Users/Phob_Calibration_Guide_Latest.md) for the version of the software you have flashed on the RP2040.
 

--- a/For_Makers/Build_Guide_2.0.md
+++ b/For_Makers/Build_Guide_2.0.md
@@ -4,7 +4,7 @@ This is an illustrated guide to making a PhobGCC 2.0, using photos taken of a Ph
 
 Newer board versions may differ slightly in appearance but this guide will still be applicable.
 
-![Motherboard Overview](For_Makers/BuildPics_2.0.1/01_Phob2_Board.jpg)
+![Motherboard Overview](../For_Makers/BuildPics_2.0.1/01_Phob2_Board.jpg)
 
 If you want to see it in motion, watch the **[PhobGCC 2.0 Assembly Video]**.
 
@@ -39,7 +39,7 @@ Come to the [PhobGCC Discord Server](https://discord.gg/yrpUu7mgzm) for advice o
 
 # Parts
 
-Some of the parts are taken from a donor Gamecube controller, while others must be sourced new. Check the [PhobGCC Ordering Guide](For_Makers/Phob2_Ordering_Guide.md) for a list of what you need to purchase.
+Some of the parts are taken from a donor Gamecube controller, while others must be sourced new. Check the [PhobGCC Ordering Guide](../For_Makers/Phob2_Ordering_Guide.md) for a list of what you need to purchase.
 
 ## New Parts
 
@@ -72,7 +72,7 @@ Begin by taking apart the donor GCC using a Tri-Wing screwdriver.
 
 Remove the motherboard.
 
-![Donor motherboard](For_Makers/BuildPics_2.0.1/05_Phob2_Harvest_Rear.jpg)
+![Donor motherboard](../For_Makers/BuildPics_2.0.1/05_Phob2_Harvest_Rear.jpg)
 
 You will want to remove the following parts from it:
 
@@ -85,12 +85,12 @@ You will want to remove the following parts from it:
 7. Rumble motor (or omit it, or use a cell rumble)
 8. Stick caps
 
-![Parts harvested](For_Makers/BuildPics_2.0.1/07_Phob2_Harvest_Parts.jpg)
+![Parts harvested](../For_Makers/BuildPics_2.0.1/07_Phob2_Harvest_Parts.jpg)
 
 If you're not familiar with removing the stickboxes, you can stick the points of tweezers between the stickbox and the potentiometers to unclip the potentiometers.
 Then, use a JIS #0 screwdriver to unscrew the screws from the bottom of the stickboxes.
 
-![Potentiometer unclipping](For_Makers/BuildPics_2.0.1/06_Phob2_Harvest_Stickbox.jpg)
+![Potentiometer unclipping](../For_Makers/BuildPics_2.0.1/06_Phob2_Harvest_Stickbox.jpg)
 
 ## Magnet Mounting
 
@@ -109,13 +109,13 @@ Do not allow it to evaporate on its own, or it will simply redeposit the grease 
 Then, I prefer to scratch up the pegs using a steel pick or a razor blade.
 This exposes clean, fresh plastic for gluing to.
 
-![Scratch stickbox pegs](For_Makers/BuildPics_2.0.1/08_Phob2_Stickbox_Prep.jpg)
+![Scratch stickbox pegs](../For_Makers/BuildPics_2.0.1/08_Phob2_Stickbox_Prep.jpg)
 
 **Do not apply superglue to the pegs!**
 
 Press-fit the magnet holders over the pegs, making sure that the hole for the magnets is offset downward.
 
-![Stickbox with magnet holders](For_Makers/BuildPics_2.0.1/09_Phob2_MagHolders.jpg)
+![Stickbox with magnet holders](../For_Makers/BuildPics_2.0.1/09_Phob2_MagHolders.jpg)
 
 The ideal offset may vary with different magnets, and different magnet/offset combinations may result in slightly different stick behavior.
 
@@ -124,13 +124,13 @@ I prefer thin superglue.
 
 **Be *very sparing* with superglue so you do not contaminate the stickbox!**
 
-![Stickbox with magnet holders](For_Makers/BuildPics_2.0.1/10_Phob2_MagnetWell.jpg)
+![Stickbox with magnet holders](../For_Makers/BuildPics_2.0.1/10_Phob2_MagnetWell.jpg)
 
 Insert magnets into the magnet wells, making sure that the magnets are all oriented horizontally.
 
 **If the magnets are not horizontal then the stick will not function.**
 
-![Stickbox with magnets](For_Makers/BuildPics_2.0.1/11_Phob2_Magnets.jpg)
+![Stickbox with magnets](../For_Makers/BuildPics_2.0.1/11_Phob2_Magnets.jpg)
 
 If you wish, you can add extra superglue on top of the magnets to ensure they are securely held in place, though this is not absolutely necessary.
 
@@ -144,19 +144,19 @@ First, use a JIS #1 screwdriver to unscrew these four screws from the backshell 
 If you attempt to use a Phillips screwdriver, you are *extremely* likely to damage the screw heads by camming out.
 Please use a JIS screwdriver so that any future modders working on the controller will have an easier time removing them.
 
-![Trigger screws to remove](For_Makers/BuildPics_2.0.1/12_Phob2_Back_Overview.jpg)
+![Trigger screws to remove](../For_Makers/BuildPics_2.0.1/12_Phob2_Back_Overview.jpg)
 
 Remove the plate above each trigger and the trigger components, and find this protruding corner on each side.
 
-![Trigger corner](For_Makers/BuildPics_2.0.1/13_Phob2_TrigCorner.jpg)
+![Trigger corner](../For_Makers/BuildPics_2.0.1/13_Phob2_TrigCorner.jpg)
 
 Using your flush cutters, remove about 1mm of height from the top of this corner.
 
-![Trigger corner trimmed](For_Makers/BuildPics_2.0.1/14_Phob2_CornerCut.jpg)
+![Trigger corner trimmed](../For_Makers/BuildPics_2.0.1/14_Phob2_CornerCut.jpg)
 
 This ensures that the tab on the trigger that moves the trigger potentiometer does not get caught on that corner.
 
-![Trigger corner clearance](For_Makers/BuildPics_2.0.1/15_Phob2_CornerClear.jpg)
+![Trigger corner clearance](../For_Makers/BuildPics_2.0.1/15_Phob2_CornerClear.jpg)
 
 ## Soldering Interlude
 
@@ -270,16 +270,16 @@ You will have to remove it.
 To do this, first simply snap it off at the motherboard side.
 You can use your bare hands, but be careful to avoid touching the button contacts, such as for the Start button, or you may contaminate them with oil.
 
-![breaking daughterboard](For_Makers/BuildPics_2.0.1/02_Phob2_Break.jpg)
+![breaking daughterboard](../For_Makers/BuildPics_2.0.1/02_Phob2_Break.jpg)
 
 Then, break the two "mousebites" off of the C-Stick daughterboard using pliers.
 Note that one is longer than the other; this is normal.
 
-![breaking mousebites](For_Makers/BuildPics_2.0.1/03_Phob2_Mousebites.jpg)
+![breaking mousebites](../For_Makers/BuildPics_2.0.1/03_Phob2_Mousebites.jpg)
 
 This should be the result.
 
-![boards laid out](For_Makers/BuildPics_2.0.1/04_Phob2_Separate.jpg)
+![boards laid out](../For_Makers/BuildPics_2.0.1/04_Phob2_Separate.jpg)
 
 ## RP2040 Programming
 
@@ -302,31 +302,31 @@ Also make sure that the switch stands perfectly square to the board, or the boar
 
 If you are using a Z button switch harvested from an original GCC, you can ignore the two large circular holes.
 
-![OEM Z](For_Makers/BuildPics_2.0.1/18_Phob2_OEM_Z.jpg)
+![OEM Z](../For_Makers/BuildPics_2.0.1/18_Phob2_OEM_Z.jpg)
 
 If you are using an Omron tactile Z switch as listed in the parts ordering guide, here are the slight tweaks you must make.
 
-![Omron Tactile Z before trimming](For_Makers/BuildPics_2.0.1/19_Phob2_TacZ.jpg)
+![Omron Tactile Z before trimming](../For_Makers/BuildPics_2.0.1/19_Phob2_TacZ.jpg)
 
 Firstly, trim the two leads off the top of the button.
 These interfere with a rib on the front shell.
 
-![Omron Tactile Z haircut](For_Makers/BuildPics_2.0.1/20_Phob2_TacZHaircut.jpg)
+![Omron Tactile Z haircut](../For_Makers/BuildPics_2.0.1/20_Phob2_TacZHaircut.jpg)
 
 Secondly, when you solder, don't use the U-shaped solder pads at the board edge.
 Instead, the structural legs go through the larger holes farther from the board edge.
 
 Make sure to not overfill the holes for the structural legs; you want the solder to sit entirely below the surface.
 
-![Omron Tactile Z soldered](For_Makers/BuildPics_2.0.1/21_Phob2_TacZ_Solder.jpg)
+![Omron Tactile Z soldered](../For_Makers/BuildPics_2.0.1/21_Phob2_TacZ_Solder.jpg)
 
 This is because you will need to trim the structural legs completely flush in order to not interfere with the trigger guards.
 
-![Omron Tactile Z legs trimmed](For_Makers/BuildPics_2.0.1/22_Phob2_TacZ_TrimLegs.jpg)
+![Omron Tactile Z legs trimmed](../For_Makers/BuildPics_2.0.1/22_Phob2_TacZ_TrimLegs.jpg)
 
 Additionally, you need to make room for the structural legs on top by trimming the button rubber as follows:
 
-![Tac Z button rubber trim](For_Makers/BuildPics_2.0.1/23_Phob2_TacZ_RubberCut.jpg)
+![Tac Z button rubber trim](../For_Makers/BuildPics_2.0.1/23_Phob2_TacZ_RubberCut.jpg)
 
 As a note for later, it may take a little more force than you may be used to when inserting the motherboard into the front shell when you use an Omron tactile Z switch.
 
@@ -336,13 +336,13 @@ This is normal, and does not cause any issues.
 
 Mount the trigger potentiometers to the back of the board. Do not mount them to the front side with all of the chips.
 
-![Trigger potentiometers soldered](For_Makers/BuildPics_2.0.1/25_Phob2_TriggerPot_Solder.jpg)
+![Trigger potentiometers soldered](../For_Makers/BuildPics_2.0.1/25_Phob2_TriggerPot_Solder.jpg)
 
 To secure them when soldering, you can tape them to the board with masking tape, or just rest the board on top of the potentiometers.
 
 Be sure to check after soldering your first joint that the potentiometer is laying flat against the back of the board before continuing.
 
-![Trigger potentiometers taped](For_Makers/BuildPics_2.0.1/24_Phob2_TriggerPots.jpg)
+![Trigger potentiometers taped](../For_Makers/BuildPics_2.0.1/24_Phob2_TriggerPots.jpg)
 
 ## Trigger Paddle Soldering
 
@@ -356,11 +356,11 @@ Apply flux to the ends of the wires, making sure not to cause them to fray if us
 
 Hold the trigger paddles in a vise and apply solder to fill the through-hole pads with solder.
 
-![Trigger paddle solder](For_Makers/BuildPics_2.0.1/16_Phob2_Paddles.jpg)
+![Trigger paddle solder](../For_Makers/BuildPics_2.0.1/16_Phob2_Paddles.jpg)
 
 Then, heat the front side of each through-hole with your soldering iron to melt it, and insert the fluxed end of the wire from the back side of the hole where the silkscreen markings are.
 
-![Trigger paddle wires](For_Makers/BuildPics_2.0.1/17_Phob2_PaddleWires.jpg)
+![Trigger paddle wires](../For_Makers/BuildPics_2.0.1/17_Phob2_PaddleWires.jpg)
 
 ## C-stick Cable Soldering
 
@@ -376,11 +376,11 @@ Then, I used the same technique as in the Trigger Paddle Soldering section to in
 
 Note that this is the side with silkscreen around the through-holes.
 
-![C-stick soldering](For_Makers/BuildPics_2.0.1/26_Phob2_Cstick_Solder.jpg)
+![C-stick soldering](../For_Makers/BuildPics_2.0.1/26_Phob2_Cstick_Solder.jpg)
 
 For these especially, if you are using individual wires I strongly recommend that you make their lengths as consistent as possible, and solder them such that the insulation ends at the same distance from the C-stick daughterboard.
 
-![C-stick wires](For_Makers/BuildPics_2.0.1/27_Phob2_Cstick_Wires.jpg)
+![C-stick wires](../For_Makers/BuildPics_2.0.1/27_Phob2_Cstick_Wires.jpg)
 
 The uniform length helps when you are inserting the wires into the motherboard.
 
@@ -388,23 +388,23 @@ Support the motherboard above the C-Stick daughterboard with the daughterboard o
 
 If you flip it around, the C-stick will not function at all.
 
-![C-stick alignmnt](For_Makers/BuildPics_2.0.1/28_Phob2_Cstick_Align.jpg)
+![C-stick alignmnt](../For_Makers/BuildPics_2.0.1/28_Phob2_Cstick_Align.jpg)
 
 Insert all of the C-Stick wires into the motherboard.
 
 Make sure that all of the wires are straight and none of them are crossed, or the C-Stick will not function.
 
-![C-stick wire insertion into the motherboard](For_Makers/BuildPics_2.0.1/29_Phob2_Cstick_InsertWires.jpg)
+![C-stick wire insertion into the motherboard](../For_Makers/BuildPics_2.0.1/29_Phob2_Cstick_InsertWires.jpg)
 
 Then solder the wires.
 
-![C-stick wire soldering to the motherboard](For_Makers/BuildPics_2.0.1/30_Phob2_Cstick_WireSolder.jpg)
+![C-stick wire soldering to the motherboard](../For_Makers/BuildPics_2.0.1/30_Phob2_Cstick_WireSolder.jpg)
 
 ## Stickbox Installation
 
 Install the stickboxes on the motherboard and the C-Stick.
 
-![Stickbox on motherboard](For_Makers/BuildPics_2.0.1/31_Phob2_StickboxInstall.jpg)
+![Stickbox on motherboard](../For_Makers/BuildPics_2.0.1/31_Phob2_StickboxInstall.jpg)
 
 You must have the magnets mounted above the 3-legged SMD Hall-Effect sensors.
 
@@ -423,11 +423,11 @@ Tuck the wires from the trigger paddles into their respective holes on the mothe
 
 For R, make sure not to mix up the holes with the extra holes for mouseswitch Z, which are nearby.
 
-![Rumble bracket on back of motherboard](For_Makers/BuildPics_2.0.1/32_Phob2_RumbleBracket.jpg)
+![Rumble bracket on back of motherboard](../For_Makers/BuildPics_2.0.1/32_Phob2_RumbleBracket.jpg)
 
 Then solder the wires in place.
 
-![Trigger wires soldered](For_Makers/BuildPics_2.0.1/33_Phob2_TriggerWires.jpg)
+![Trigger wires soldered](../For_Makers/BuildPics_2.0.1/33_Phob2_TriggerWires.jpg)
 
 ## Controller Cable Soldering
 
@@ -437,11 +437,11 @@ The cable must go in the back of the motherboard.
 
 If you are using an OEM cable harvested from a first-party Gamecube controller, the black wire should be placed farthest from the center of the controller, and the blue wire closest to the center of the controller.
 
-![Cable installation with colors labeled](For_Makers/BuildPics_2.0.1/34_Phob2_CableInstall.jpg)
+![Cable installation with colors labeled](../For_Makers/BuildPics_2.0.1/34_Phob2_CableInstall.jpg)
 
 Secure the wire in place, then solder the pins to the pads on the top of the motherboard.
 
-![Cable installation with colors labeled](For_Makers/BuildPics_2.0.1/35_Phob2_CableSolder.jpg)
+![Cable installation with colors labeled](../For_Makers/BuildPics_2.0.1/35_Phob2_CableSolder.jpg)
 
 ## OPTIONAL PhobVision installation and soldering
 
@@ -456,13 +456,13 @@ Nonetheless, this guide shows you how to do it so that it fits around the OEM ru
 
 Begin by taking the backshell and marking a point 0.5 inches or 13 mm down directly below the edge, aligned with the center of this tab.
 
-![Marked drill hole](For_Makers/BuildPics_2.0.1/36_PhobVision_Mark.jpg)
+![Marked drill hole](../For_Makers/BuildPics_2.0.1/36_PhobVision_Mark.jpg)
 
 Using a *split-point drill bit* to help prevent the bit from wandering around, drill a 7mm diameter hole in the back of the controller.
 
 You may also use a 9/32" bit or a Letter J drill bit.
 
-![PhobVision hole drilled](For_Makers/BuildPics_2.0.1/37_PhobVision_Drill.jpg)
+![PhobVision hole drilled](../For_Makers/BuildPics_2.0.1/37_PhobVision_Drill.jpg)
 
 Note that on this particular shell, the bit wandered slightly towards the centerline of the controller, which is fine.
 
@@ -470,25 +470,25 @@ If the bit wanders towards the side of the controller, you may need to carve out
 
 In this case, the hole instead intersects a rib that only exists on T3 shells that you should remove in the vicinity of the hole.
 
-![Rib interference with hole](For_Makers/BuildPics_2.0.1/38_PhobVision_Rib.jpg)
+![Rib interference with hole](../For_Makers/BuildPics_2.0.1/38_PhobVision_Rib.jpg)
 
 Simply cut the rib off with flush cutters.
 
-![Rib cut near hole](For_Makers/BuildPics_2.0.1/39_PhobVision_CutRib.jpg)
+![Rib cut near hole](../For_Makers/BuildPics_2.0.1/39_PhobVision_CutRib.jpg)
 
 Next up we must prepare the 3.5mm TRRS jack for installation.
 
-![Untouched jack](For_Makers/BuildPics_2.0.1/40_PhobVision_Jack.jpg)
+![Untouched jack](../For_Makers/BuildPics_2.0.1/40_PhobVision_Jack.jpg)
 
 To get the jack to fit with an OEM rumble motor, use pliers to bend the tabs on the end sideways.
 
 Note which tabs are used for what.
 
-![Jack with bent tabs, labeled](For_Makers/BuildPics_2.0.1/41_PhobVision_Bend.jpg)
+![Jack with bent tabs, labeled](../For_Makers/BuildPics_2.0.1/41_PhobVision_Bend.jpg)
 
 Apply flux to the two bent silver tabs and tin them generously with solder.
 
-![Tinned tabs on jack](For_Makers/BuildPics_2.0.1/42_PhobVision_Tin.jpg)
+![Tinned tabs on jack](../For_Makers/BuildPics_2.0.1/42_PhobVision_Tin.jpg)
 
 Cut a two-pin JST-PH pigtail's wires to 3 inches long (75mm), strip the ends, and apply flux.
 Shorter wires give less slack when maneuvering, and longer wires are hard to fit, so be fairly precise with the length here.
@@ -497,17 +497,17 @@ Then solder them to the two tinned tabs.
 
 Make sure that the black wire goes to the middle tab, and the red wire goes to the other silver tab.
 
-![Wires soldered to jack](For_Makers/BuildPics_2.0.1/43_PhobVision_Solder.jpg)
+![Wires soldered to jack](../For_Makers/BuildPics_2.0.1/43_PhobVision_Solder.jpg)
 
 Make sure the wires are soldered to the back side of the tabs so that they do not stick out past the end.
 
-![Wires do not protrude past the end of jack](For_Makers/BuildPics_2.0.1/44_PhobVision_Flat.jpg)
+![Wires do not protrude past the end of jack](../For_Makers/BuildPics_2.0.1/44_PhobVision_Flat.jpg)
 
 Generously apply hot glue between the wires and the barrel of the TRRS jack in order to provide strain relief.
 
 Again, do not let it protrude much past the end of the jack.
 
-![Hot glue used as strain relief](For_Makers/BuildPics_2.0.1/45_PhobVision_Glue.jpg)
+![Hot glue used as strain relief](../For_Makers/BuildPics_2.0.1/45_PhobVision_Glue.jpg)
 
 Next, cut 1.25" (32mm) long wires, strip both ends, and apply flux.
 Shorter wires might not reach, and longer can interfere with closing the controller, so be precise with the length here.
@@ -517,11 +517,11 @@ You must leave the connector in the receptacle while soldering, or else the pins
 
 Make sure to match red with red and black with black; I used the scrap ends of the pigtail wires for this so the colors match nicely.
 
-![JST receptacle soldered](For_Makers/BuildPics_2.0.1/46_PhobVision_JST_Solder.jpg)
+![JST receptacle soldered](../For_Makers/BuildPics_2.0.1/46_PhobVision_JST_Solder.jpg)
 
 Insert the receptacle's wires into the back of the motherboard at the J2 through-hole pads, and solder them on the front of the motherboard.
 
-![JST soldered to phobvision pads](For_Makers/BuildPics_2.0.1/47_PhobVision_Mobo_Solder.jpg)
+![JST soldered to phobvision pads](../For_Makers/BuildPics_2.0.1/47_PhobVision_Mobo_Solder.jpg)
 
 At this point, if you are installing rumble, mount the rumble motor in the rumble bracket by inserting it into the rectangular box.
 Make sure that the shaft is on the cable side, and the motor is rotated so that the wires are on the D-pad side, close to the edge of the box.
@@ -532,15 +532,15 @@ Tuck the rumble wires in the clip on the rumble bracket.
 
 Then hot glue the PhobVision JST receptacle to the rumble bracket like depicted, ensuring that the opening is not blocked by the glue.
 
-![JST glued to rumble bracket](For_Makers/BuildPics_2.0.1/48_PhobVision_JST_Glue.jpg)
+![JST glued to rumble bracket](../For_Makers/BuildPics_2.0.1/48_PhobVision_JST_Glue.jpg)
 
 Next, install the TRRS jack in the backshell and install the nut on the outside using pliers.
 
 I recommend you orient the jack so that the wires initially go towards the center of the controller, then loop around towards the triggers.
 
-![Jack in the backshell with suggested wire orientation](For_Makers/BuildPics_2.0.1/49_PhobVision_Jack_Install.jpg)
+![Jack in the backshell with suggested wire orientation](../For_Makers/BuildPics_2.0.1/49_PhobVision_Jack_Install.jpg)
 
-![Nut holding the jack in place](For_Makers/BuildPics_2.0.1/50_PhobVision_Nut.jpg)
+![Nut holding the jack in place](../For_Makers/BuildPics_2.0.1/50_PhobVision_Nut.jpg)
 
 ## Rumble Motor Soldering
 
@@ -551,11 +551,11 @@ Make sure that the shaft is on the cable side, and the motor is rotated so that 
 
 Now your PhobGCC should be complete!
 
-![Front of PhobGCC 2](For_Makers/BuildPics_2.0.1/Phob2_Front.jpg)
+![Front of PhobGCC 2](../For_Makers/BuildPics_2.0.1/Phob2_Front.jpg)
 
-![Rear of PhobGCC 2](For_Makers/BuildPics_2.0.1/Phob2_Back.jpg)
+![Rear of PhobGCC 2](../For_Makers/BuildPics_2.0.1/Phob2_Back.jpg)
 
-Reassemble your controller, and follow the Initial Setup procedure in the [PhobGCC Calibration Guide](For_Users/Phob_Calibration_Guide_Latest.md) for the version of the software you have flashed on the RP2040.
+Reassemble your controller, and follow the Initial Setup procedure in the [PhobGCC Calibration Guide](../For_Users/Phob_Calibration_Guide_Latest.md) for the version of the software you have flashed on the RP2040.
 
 And, enjoy!
 

--- a/For_Makers/Phob2_Elecrow_Ordering_Guide.md
+++ b/For_Makers/Phob2_Elecrow_Ordering_Guide.md
@@ -14,11 +14,11 @@ This is an illustrated guide to ordering PhobGCC PCBs via the Elecrow Board Hous
 
 Download the files available in the [PhobGCCv2-HW Github](https://github.com/PhobGCC/PhobGCCv2-HW/releases/tag/v2.0.5) in the releases section as shown below:
 
-![PHOB2_ELECROW_BOARD_RELEASE](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_release.PNG?raw=true)
+![PHOB2_ELECROW_BOARD_RELEASE](For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_release.PNG?raw=true)
 
 Once you've extracted the files from the .zip, you should have two files. The Phob2_Gerbers .zip and the Elecrow Info Excel spreadsheet. Open up the spreadsheet and you should see in the PCB Specification sheet as follows:
 
-![PHOB2_ELECROW_BOARD_OPTIONS](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_options.PNG?raw=true)
+![PHOB2_ELECROW_BOARD_OPTIONS](For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_options.PNG?raw=true)
 
 Here is where you'll want to set your board quantity, PCB color, and text color. You can see the exact settings availability on [Elecrow's website](https://www.elecrow.com/pcb-manufacturing.html), but for a short hand you can set board quantities to be 5, 10, 15, 20, 25, 30, 40, 50, 75, and 100. For PCB Color, you can choose between Green, Red, Yellow, Blue, White, Black, Purple, or Matte Black. If, and only if, you order White or Yellow PCBs, you need to change the text color from white to black. Once you have your specifications set, save the file, close it, and re-open it to ensure it saved properly.
 
@@ -47,9 +47,9 @@ Attach the Gerbers .zip and the spreadsheet to the email. Title it "PCB Assembly
 
 In 24-48 hours, they will reply with an excel spreadsheet containing the results of your quote. On the Total Page at the bottom will be the final cost. If this cost is acceptable to you, you then proceed to the [Elecrow website for PCB assembly](https://www.elecrow.com/pcb-assembly.html). On here, set the name of the person who emailed you your final cost as the Project Manager name and set the "Qty" as the final cost rounded up to dollar. You can See examples below:
 
-![PHOB2_ELECROW_BOARD_COST](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_cost.PNG?raw=true)
+![PHOB2_ELECROW_BOARD_COST](For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_cost.PNG?raw=true)
 
-![PHOB2_ELECROW_BOARD_CHECKOUT](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_web.PNG?raw=true)
+![PHOB2_ELECROW_BOARD_CHECKOUT](For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_web.PNG?raw=true)
 
 You can then click "Add To Cart", and proceed to checkout. Once you have checked out, you need to make a note of the order #. This will appear on screen immediately, but if you forget, you can check your email for a receipt from Elecrow. You then need to reply to the quotation email with the order number. You can use the template below:
 

--- a/For_Makers/Phob2_Elecrow_Ordering_Guide.md
+++ b/For_Makers/Phob2_Elecrow_Ordering_Guide.md
@@ -14,11 +14,11 @@ This is an illustrated guide to ordering PhobGCC PCBs via the Elecrow Board Hous
 
 Download the files available in the [PhobGCCv2-HW Github](https://github.com/PhobGCC/PhobGCCv2-HW/releases/tag/v2.0.5) in the releases section as shown below:
 
-![PHOB2_ELECROW_BOARD_RELEASE](For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_release.PNG?raw=true)
+![PHOB2_ELECROW_BOARD_RELEASE](For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_release.PNG)
 
 Once you've extracted the files from the .zip, you should have two files. The Phob2_Gerbers .zip and the Elecrow Info Excel spreadsheet. Open up the spreadsheet and you should see in the PCB Specification sheet as follows:
 
-![PHOB2_ELECROW_BOARD_OPTIONS](For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_options.PNG?raw=true)
+![PHOB2_ELECROW_BOARD_OPTIONS](For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_options.PNG)
 
 Here is where you'll want to set your board quantity, PCB color, and text color. You can see the exact settings availability on [Elecrow's website](https://www.elecrow.com/pcb-manufacturing.html), but for a short hand you can set board quantities to be 5, 10, 15, 20, 25, 30, 40, 50, 75, and 100. For PCB Color, you can choose between Green, Red, Yellow, Blue, White, Black, Purple, or Matte Black. If, and only if, you order White or Yellow PCBs, you need to change the text color from white to black. Once you have your specifications set, save the file, close it, and re-open it to ensure it saved properly.
 
@@ -47,9 +47,9 @@ Attach the Gerbers .zip and the spreadsheet to the email. Title it "PCB Assembly
 
 In 24-48 hours, they will reply with an excel spreadsheet containing the results of your quote. On the Total Page at the bottom will be the final cost. If this cost is acceptable to you, you then proceed to the [Elecrow website for PCB assembly](https://www.elecrow.com/pcb-assembly.html). On here, set the name of the person who emailed you your final cost as the Project Manager name and set the "Qty" as the final cost rounded up to dollar. You can See examples below:
 
-![PHOB2_ELECROW_BOARD_COST](For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_cost.PNG?raw=true)
+![PHOB2_ELECROW_BOARD_COST](For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_cost.PNG)
 
-![PHOB2_ELECROW_BOARD_CHECKOUT](For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_web.PNG?raw=true)
+![PHOB2_ELECROW_BOARD_CHECKOUT](For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_web.PNG)
 
 You can then click "Add To Cart", and proceed to checkout. Once you have checked out, you need to make a note of the order #. This will appear on screen immediately, but if you forget, you can check your email for a receipt from Elecrow. You then need to reply to the quotation email with the order number. You can use the template below:
 

--- a/For_Makers/Phob2_Elecrow_Ordering_Guide.md
+++ b/For_Makers/Phob2_Elecrow_Ordering_Guide.md
@@ -14,11 +14,11 @@ This is an illustrated guide to ordering PhobGCC PCBs via the Elecrow Board Hous
 
 Download the files available in the [PhobGCCv2-HW Github](https://github.com/PhobGCC/PhobGCCv2-HW/releases/tag/v2.0.5) in the releases section as shown below:
 
-![PHOB2_ELECROW_BOARD_RELEASE](For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_release.PNG)
+![PHOB2_ELECROW_BOARD_RELEASE](../For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_release.PNG)
 
 Once you've extracted the files from the .zip, you should have two files. The Phob2_Gerbers .zip and the Elecrow Info Excel spreadsheet. Open up the spreadsheet and you should see in the PCB Specification sheet as follows:
 
-![PHOB2_ELECROW_BOARD_OPTIONS](For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_options.PNG)
+![PHOB2_ELECROW_BOARD_OPTIONS](../For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_options.PNG)
 
 Here is where you'll want to set your board quantity, PCB color, and text color. You can see the exact settings availability on [Elecrow's website](https://www.elecrow.com/pcb-manufacturing.html), but for a short hand you can set board quantities to be 5, 10, 15, 20, 25, 30, 40, 50, 75, and 100. For PCB Color, you can choose between Green, Red, Yellow, Blue, White, Black, Purple, or Matte Black. If, and only if, you order White or Yellow PCBs, you need to change the text color from white to black. Once you have your specifications set, save the file, close it, and re-open it to ensure it saved properly.
 
@@ -47,9 +47,9 @@ Attach the Gerbers .zip and the spreadsheet to the email. Title it "PCB Assembly
 
 In 24-48 hours, they will reply with an excel spreadsheet containing the results of your quote. On the Total Page at the bottom will be the final cost. If this cost is acceptable to you, you then proceed to the [Elecrow website for PCB assembly](https://www.elecrow.com/pcb-assembly.html). On here, set the name of the person who emailed you your final cost as the Project Manager name and set the "Qty" as the final cost rounded up to dollar. You can See examples below:
 
-![PHOB2_ELECROW_BOARD_COST](For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_cost.PNG)
+![PHOB2_ELECROW_BOARD_COST](../For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_cost.PNG)
 
-![PHOB2_ELECROW_BOARD_CHECKOUT](For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_web.PNG)
+![PHOB2_ELECROW_BOARD_CHECKOUT](../For_Makers/Phob_Ordering_Guide_Images/phob2_elecrow_web.PNG)
 
 You can then click "Add To Cart", and proceed to checkout. Once you have checked out, you need to make a note of the order #. This will appear on screen immediately, but if you forget, you can check your email for a receipt from Elecrow. You then need to reply to the quotation email with the order number. You can use the template below:
 

--- a/For_Makers/Phob2_JLCPCB_Ordering_Guide.md
+++ b/For_Makers/Phob2_JLCPCB_Ordering_Guide.md
@@ -31,7 +31,7 @@ The following parts usually have low stock and pre-ordering them is advised:
 
 Once you've clicked on each link and added the quantities you need into your cart, click the cart icon in the top right, go to the "Parts Manager Tab", to the "Order Parts" subtab, to the "Cart" subtab as follows:
 
-![PHOB_PREORDER_PARTS](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob2_preorder_parts.PNG?raw=true)
+![PHOB_PREORDER_PARTS](For_Makers/Phob_Ordering_Guide_Images/phob2_preorder_parts.PNG?raw=true)
 
 This is where you double-check the part quantities you've selected and make sure that they're all checked, even if in stock.
 Once you checkout, JLC will attempt to purchase those parts for you at the quoted price.
@@ -48,20 +48,20 @@ This may take one or two weeks.
 
 Download the files available in the [PhobGCCv2-HW Github](https://github.com/PhobGCC/PhobGCCv2-HW/releases/tag/v2.0.5) in the releases section as shown below:
 
-![PHOB2_BOARD_RELEASE](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob2_board_release.png?raw=true)
+![PHOB2_BOARD_RELEASE](For_Makers/Phob_Ordering_Guide_Images/phob2_board_release.png?raw=true)
 
 Make sure to redownload the latest even if you already downloaded it in the past, as occasionally we make changes to the components to account for stock shortages.
 
 Once you've extracted the files from the .zip, you should have three files. The Phob2_Gerbers .zip, the Phob2_Bom.csv, and the Phob2_Pos.csv. Click "Order Now" on JLCPCB, make sure you are set to "Standard PCB/PCBA" tab, click "Add Gerber File", and upload the Phob2_Gerbers.zip. Once the files are uploaded, you should see the board process and then load in as shown below:
 
-![PHOB2_BOARD](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob2_board.PNG?raw=true)
+![PHOB2_BOARD](For_Makers/Phob_Ordering_Guide_Images/phob2_board.PNG?raw=true)
 
 Once you've checked that the size is set to 90.26x125.5mm, you can progress with configuring it.
 The recommended settings are the defaults, setting your board quantity, setting "Different Design" to 2, and setting the Surface Finish to ENIG, as seen below:
 
 **NOTE: ONLY ORDER THE BOARD QUANTITY YOU HAVE PARTS FOR!**
 
-![PHOB2_SETTINGS](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob2_settings.PNG?raw=true)
+![PHOB2_SETTINGS](For_Makers/Phob_Ordering_Guide_Images/phob2_settings.PNG?raw=true)
 
 Scroll down to PCB Assembly and toggle it on the right.
 Select Standard PCBA Type (Not available for large orders or colors), the top side, and confirm parts placement as seen below.
@@ -70,14 +70,14 @@ Select Standard PCBA Type (Not available for large orders or colors), the top si
 
 **NOTE2: If arranging group buys or purchasing in large quantities, we strongly suggest using Standard PCBA so DOA boards are less likely.**
 
-![PHOB2_ASM](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob2_asm.PNG?raw=true)
+![PHOB2_ASM](For_Makers/Phob_Ordering_Guide_Images/phob2_asm.PNG?raw=true)
 
 Click "Confirm" and then upload the Phob2_Bom.csv to the left and and the Phob2_Pos.csv to the right.
 Set the usage description to Research/Education/DIY -> DIY HS Code and click "Next".
 The text at the top of the next screen should look like the following with all 25 confirmed.
 If they are not confirmed, and are not one of the five above in the pre-ordering section, stop ordering and ask in the [PhobGCC Discord](https://discord.gg/yrpUu7mgzm).
 
-![PHOB2_PARTS](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob2_parts.PNG?raw=true)
+![PHOB2_PARTS](For_Makers/Phob_Ordering_Guide_Images/phob2_parts.PNG?raw=true)
 
 After clicking "Next", you'll be presented with a view of the parts on the board.
 If this screen is corrupted, that's okay.

--- a/For_Makers/Phob2_JLCPCB_Ordering_Guide.md
+++ b/For_Makers/Phob2_JLCPCB_Ordering_Guide.md
@@ -31,7 +31,7 @@ The following parts usually have low stock and pre-ordering them is advised:
 
 Once you've clicked on each link and added the quantities you need into your cart, click the cart icon in the top right, go to the "Parts Manager Tab", to the "Order Parts" subtab, to the "Cart" subtab as follows:
 
-![PHOB_PREORDER_PARTS](For_Makers/Phob_Ordering_Guide_Images/phob2_preorder_parts.PNG)
+![PHOB_PREORDER_PARTS](../For_Makers/Phob_Ordering_Guide_Images/phob2_preorder_parts.PNG)
 
 This is where you double-check the part quantities you've selected and make sure that they're all checked, even if in stock.
 Once you checkout, JLC will attempt to purchase those parts for you at the quoted price.
@@ -48,20 +48,20 @@ This may take one or two weeks.
 
 Download the files available in the [PhobGCCv2-HW Github](https://github.com/PhobGCC/PhobGCCv2-HW/releases/tag/v2.0.5) in the releases section as shown below:
 
-![PHOB2_BOARD_RELEASE](For_Makers/Phob_Ordering_Guide_Images/phob2_board_release.png)
+![PHOB2_BOARD_RELEASE](../For_Makers/Phob_Ordering_Guide_Images/phob2_board_release.png)
 
 Make sure to redownload the latest even if you already downloaded it in the past, as occasionally we make changes to the components to account for stock shortages.
 
 Once you've extracted the files from the .zip, you should have three files. The Phob2_Gerbers .zip, the Phob2_Bom.csv, and the Phob2_Pos.csv. Click "Order Now" on JLCPCB, make sure you are set to "Standard PCB/PCBA" tab, click "Add Gerber File", and upload the Phob2_Gerbers.zip. Once the files are uploaded, you should see the board process and then load in as shown below:
 
-![PHOB2_BOARD](For_Makers/Phob_Ordering_Guide_Images/phob2_board.PNG)
+![PHOB2_BOARD](../For_Makers/Phob_Ordering_Guide_Images/phob2_board.PNG)
 
 Once you've checked that the size is set to 90.26x125.5mm, you can progress with configuring it.
 The recommended settings are the defaults, setting your board quantity, setting "Different Design" to 2, and setting the Surface Finish to ENIG, as seen below:
 
 **NOTE: ONLY ORDER THE BOARD QUANTITY YOU HAVE PARTS FOR!**
 
-![PHOB2_SETTINGS](For_Makers/Phob_Ordering_Guide_Images/phob2_settings.PNG)
+![PHOB2_SETTINGS](../For_Makers/Phob_Ordering_Guide_Images/phob2_settings.PNG)
 
 Scroll down to PCB Assembly and toggle it on the right.
 Select Standard PCBA Type (Not available for large orders or colors), the top side, and confirm parts placement as seen below.
@@ -70,14 +70,14 @@ Select Standard PCBA Type (Not available for large orders or colors), the top si
 
 **NOTE2: If arranging group buys or purchasing in large quantities, we strongly suggest using Standard PCBA so DOA boards are less likely.**
 
-![PHOB2_ASM](For_Makers/Phob_Ordering_Guide_Images/phob2_asm.PNG)
+![PHOB2_ASM](../For_Makers/Phob_Ordering_Guide_Images/phob2_asm.PNG)
 
 Click "Confirm" and then upload the Phob2_Bom.csv to the left and and the Phob2_Pos.csv to the right.
 Set the usage description to Research/Education/DIY -> DIY HS Code and click "Next".
 The text at the top of the next screen should look like the following with all 25 confirmed.
 If they are not confirmed, and are not one of the five above in the pre-ordering section, stop ordering and ask in the [PhobGCC Discord](https://discord.gg/yrpUu7mgzm).
 
-![PHOB2_PARTS](For_Makers/Phob_Ordering_Guide_Images/phob2_parts.PNG)
+![PHOB2_PARTS](../For_Makers/Phob_Ordering_Guide_Images/phob2_parts.PNG)
 
 After clicking "Next", you'll be presented with a view of the parts on the board.
 If this screen is corrupted, that's okay.

--- a/For_Makers/Phob2_JLCPCB_Ordering_Guide.md
+++ b/For_Makers/Phob2_JLCPCB_Ordering_Guide.md
@@ -31,7 +31,7 @@ The following parts usually have low stock and pre-ordering them is advised:
 
 Once you've clicked on each link and added the quantities you need into your cart, click the cart icon in the top right, go to the "Parts Manager Tab", to the "Order Parts" subtab, to the "Cart" subtab as follows:
 
-![PHOB_PREORDER_PARTS](For_Makers/Phob_Ordering_Guide_Images/phob2_preorder_parts.PNG?raw=true)
+![PHOB_PREORDER_PARTS](For_Makers/Phob_Ordering_Guide_Images/phob2_preorder_parts.PNG)
 
 This is where you double-check the part quantities you've selected and make sure that they're all checked, even if in stock.
 Once you checkout, JLC will attempt to purchase those parts for you at the quoted price.
@@ -48,20 +48,20 @@ This may take one or two weeks.
 
 Download the files available in the [PhobGCCv2-HW Github](https://github.com/PhobGCC/PhobGCCv2-HW/releases/tag/v2.0.5) in the releases section as shown below:
 
-![PHOB2_BOARD_RELEASE](For_Makers/Phob_Ordering_Guide_Images/phob2_board_release.png?raw=true)
+![PHOB2_BOARD_RELEASE](For_Makers/Phob_Ordering_Guide_Images/phob2_board_release.png)
 
 Make sure to redownload the latest even if you already downloaded it in the past, as occasionally we make changes to the components to account for stock shortages.
 
 Once you've extracted the files from the .zip, you should have three files. The Phob2_Gerbers .zip, the Phob2_Bom.csv, and the Phob2_Pos.csv. Click "Order Now" on JLCPCB, make sure you are set to "Standard PCB/PCBA" tab, click "Add Gerber File", and upload the Phob2_Gerbers.zip. Once the files are uploaded, you should see the board process and then load in as shown below:
 
-![PHOB2_BOARD](For_Makers/Phob_Ordering_Guide_Images/phob2_board.PNG?raw=true)
+![PHOB2_BOARD](For_Makers/Phob_Ordering_Guide_Images/phob2_board.PNG)
 
 Once you've checked that the size is set to 90.26x125.5mm, you can progress with configuring it.
 The recommended settings are the defaults, setting your board quantity, setting "Different Design" to 2, and setting the Surface Finish to ENIG, as seen below:
 
 **NOTE: ONLY ORDER THE BOARD QUANTITY YOU HAVE PARTS FOR!**
 
-![PHOB2_SETTINGS](For_Makers/Phob_Ordering_Guide_Images/phob2_settings.PNG?raw=true)
+![PHOB2_SETTINGS](For_Makers/Phob_Ordering_Guide_Images/phob2_settings.PNG)
 
 Scroll down to PCB Assembly and toggle it on the right.
 Select Standard PCBA Type (Not available for large orders or colors), the top side, and confirm parts placement as seen below.
@@ -70,14 +70,14 @@ Select Standard PCBA Type (Not available for large orders or colors), the top si
 
 **NOTE2: If arranging group buys or purchasing in large quantities, we strongly suggest using Standard PCBA so DOA boards are less likely.**
 
-![PHOB2_ASM](For_Makers/Phob_Ordering_Guide_Images/phob2_asm.PNG?raw=true)
+![PHOB2_ASM](For_Makers/Phob_Ordering_Guide_Images/phob2_asm.PNG)
 
 Click "Confirm" and then upload the Phob2_Bom.csv to the left and and the Phob2_Pos.csv to the right.
 Set the usage description to Research/Education/DIY -> DIY HS Code and click "Next".
 The text at the top of the next screen should look like the following with all 25 confirmed.
 If they are not confirmed, and are not one of the five above in the pre-ordering section, stop ordering and ask in the [PhobGCC Discord](https://discord.gg/yrpUu7mgzm).
 
-![PHOB2_PARTS](For_Makers/Phob_Ordering_Guide_Images/phob2_parts.PNG?raw=true)
+![PHOB2_PARTS](For_Makers/Phob_Ordering_Guide_Images/phob2_parts.PNG)
 
 After clicking "Next", you'll be presented with a view of the parts on the board.
 If this screen is corrupted, that's okay.

--- a/For_Makers/Phob2_Ordering_Guide.md
+++ b/For_Makers/Phob2_Ordering_Guide.md
@@ -48,11 +48,11 @@ There are two board houses you can purchase from, with their own benefits and dr
 
 Elecrow is the preferred board house, as they have proper quality control and validation. They do the testing procedure to ensure the boards came out cleanly and to ensure you will not receive a dead-on-arrival board. The drawbacks is that they often take 3-4 weeks for arrival and are 50% more expensive than the alternative option.
 
-[Elecrow Ordering Guide](For_Makers/Phob2_Elecrow_Ordering_Guide.md)
+[Elecrow Ordering Guide](../For_Makers/Phob2_Elecrow_Ordering_Guide.md)
 
 JLCPCB is the secondary board house, as they lack significant quality control to ensure the board is assembled properly. JLC Economic assembly **should not** be used as the quality of the boards will be terrible and you risk dead-on-arrival boards. JLC Standard Assembly is better, but you risk poor plating and solder mask issues. The advantages to JLC is that they ship much faster than Elecrow (2 weeks) and are 30% less expensive.
 
-[JLCPCB Ordering Guide](For_Makers/Phob2_JLCPCB_Ordering_Guide.md)
+[JLCPCB Ordering Guide](../For_Makers/Phob2_JLCPCB_Ordering_Guide.md)
 
 ## Optional: Purchasing LR Trigger Paddles
 
@@ -60,11 +60,11 @@ If you don't or can't use OEM GCC Trigger paddles, you can order trigger paddles
 
 First, you can download the files available in the [PhobGCCv2-HW Github](https://github.com/PhobGCC/PhobGCCv2-HW/releases/tag/v2.0.5) in the releases section as shown below:
 
-![PHOB2_PADDLE_RELEASE](For_Makers/Phob_Ordering_Guide_Images/phob2_paddle_release.png)
+![PHOB2_PADDLE_RELEASE](../For_Makers/Phob_Ordering_Guide_Images/phob2_paddle_release.png)
 
 Click "Order Now" on JLCPCB, make sure you are set to "Standard PCB/PCBA" tab, click "Add Gerber File", and upload the Trigger_Paddle_Gerbers.zip. Once the files are uploaded, you should see the board process and then load in as shown below:
 
-![TRIGGER_BOARD](For_Makers/Phob_Ordering_Guide_Images/trigger_board.PNG)
+![TRIGGER_BOARD](../For_Makers/Phob_Ordering_Guide_Images/trigger_board.PNG)
 
 Once you've checked that the size is set to 9.7x41.72mm, you can progress with configuring it.
 The recommended settings are the defaults, setting your board quantity, setting "Different Design" to 2, and setting the Surface Finish to ENIG, as seen below:
@@ -73,7 +73,7 @@ The recommended settings are the defaults, setting your board quantity, setting 
 
 **NOTE2: SINCE THESE BOARDS ARE SO SMALL, THE QUANTITY DOESN'T CHANGE THE PRICE. WE SUGGEST ORDERING PLENTY SINCE ITS CHEAP. THE DIFFERENCE BETWEEN 20 AND 200 IS $18.**
 
-![TRIGGER_SETTINGS](For_Makers/Phob_Ordering_Guide_Images/trigger_settings.PNG)
+![TRIGGER_SETTINGS](../For_Makers/Phob_Ordering_Guide_Images/trigger_settings.PNG)
 
 You can then click "Save To Cart" and pay for your boards.
 
@@ -85,17 +85,17 @@ If you can't source magnet mounts locally or via [Etsy](https://www.etsy.com/), 
 
 First, you can download the files available in the [PhobGCCv2-HW Github](https://github.com/PhobGCC/PhobGCCv2-HW/releases/tag/v2.0.5) in the releases section as shown below:
 
-![PHOB2_MAGNET_RELEASE](For_Makers/Phob_Ordering_Guide_Images/phob2_magnet_release.png)
+![PHOB2_MAGNET_RELEASE](../For_Makers/Phob_Ordering_Guide_Images/phob2_magnet_release.png)
 
 Click "Order Now" on JLCPCB, make sure you are set to "3D Printing" tab, click "Add 3D Files", and upload the DH1H1_Magnet_Holder_JLCPCB.STL. Once the file is uploaded, you should see it render as shown below:
 
-![MAGNET_MOUNTS](For_Makers/Phob_Ordering_Guide_Images/dh1h1_mounts.PNG)
+![MAGNET_MOUNTS](../For_Makers/Phob_Ordering_Guide_Images/dh1h1_mounts.PNG)
 
 The recommended settings are SLS Nylon. You then set the product description to Other -> Fastener as shown below
 
 **NOTE: QUANTITY 1 GETS YOU 10 MOUNTS, WHICH IS ENOUGH FOR 2.5 PHOBS. 2 GETS YOU 20 MOUNTS FOR 5 PHOBS. MAKE SURE YOU ORDER ENOUGH!**
 
-![MAGNET_SETTINGS](For_Makers/Phob_Ordering_Guide_Images/magnet_settings.PNG)
+![MAGNET_SETTINGS](../For_Makers/Phob_Ordering_Guide_Images/magnet_settings.PNG)
 
 You can then click "Save To Cart" and pay for your mounts.
 
@@ -160,4 +160,4 @@ The GCC-specific Parts have a few different methods of acquisition
 
 # Assembly
 
-Once you have all the parts you need, follow the [build guide](For_Makers/Build_Guide_2.0.md) to assemble your PhobGCC.
+Once you have all the parts you need, follow the [build guide](../For_Makers/Build_Guide_2.0.md) to assemble your PhobGCC.

--- a/For_Makers/Phob2_Ordering_Guide.md
+++ b/For_Makers/Phob2_Ordering_Guide.md
@@ -48,11 +48,11 @@ There are two board houses you can purchase from, with their own benefits and dr
 
 Elecrow is the preferred board house, as they have proper quality control and validation. They do the testing procedure to ensure the boards came out cleanly and to ensure you will not receive a dead-on-arrival board. The drawbacks is that they often take 3-4 weeks for arrival and are 50% more expensive than the alternative option.
 
-[Elecrow Ordering Guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob2_Elecrow_Ordering_Guide.md)
+[Elecrow Ordering Guide](For_Makers/Phob2_Elecrow_Ordering_Guide.md)
 
 JLCPCB is the secondary board house, as they lack significant quality control to ensure the board is assembled properly. JLC Economic assembly **should not** be used as the quality of the boards will be terrible and you risk dead-on-arrival boards. JLC Standard Assembly is better, but you risk poor plating and solder mask issues. The advantages to JLC is that they ship much faster than Elecrow (2 weeks) and are 30% less expensive.
 
-[JLCPCB Ordering Guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob2_JLCPCB_Ordering_Guide.md)
+[JLCPCB Ordering Guide](For_Makers/Phob2_JLCPCB_Ordering_Guide.md)
 
 ## Optional: Purchasing LR Trigger Paddles
 
@@ -60,11 +60,11 @@ If you don't or can't use OEM GCC Trigger paddles, you can order trigger paddles
 
 First, you can download the files available in the [PhobGCCv2-HW Github](https://github.com/PhobGCC/PhobGCCv2-HW/releases/tag/v2.0.5) in the releases section as shown below:
 
-![PHOB2_PADDLE_RELEASE](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob2_paddle_release.png?raw=true)
+![PHOB2_PADDLE_RELEASE](For_Makers/Phob_Ordering_Guide_Images/phob2_paddle_release.png?raw=true)
 
 Click "Order Now" on JLCPCB, make sure you are set to "Standard PCB/PCBA" tab, click "Add Gerber File", and upload the Trigger_Paddle_Gerbers.zip. Once the files are uploaded, you should see the board process and then load in as shown below:
 
-![TRIGGER_BOARD](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/trigger_board.PNG?raw=true)
+![TRIGGER_BOARD](For_Makers/Phob_Ordering_Guide_Images/trigger_board.PNG?raw=true)
 
 Once you've checked that the size is set to 9.7x41.72mm, you can progress with configuring it.
 The recommended settings are the defaults, setting your board quantity, setting "Different Design" to 2, and setting the Surface Finish to ENIG, as seen below:
@@ -73,7 +73,7 @@ The recommended settings are the defaults, setting your board quantity, setting 
 
 **NOTE2: SINCE THESE BOARDS ARE SO SMALL, THE QUANTITY DOESN'T CHANGE THE PRICE. WE SUGGEST ORDERING PLENTY SINCE ITS CHEAP. THE DIFFERENCE BETWEEN 20 AND 200 IS $18.**
 
-![TRIGGER_SETTINGS](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/trigger_settings.PNG?raw=true)
+![TRIGGER_SETTINGS](For_Makers/Phob_Ordering_Guide_Images/trigger_settings.PNG?raw=true)
 
 You can then click "Save To Cart" and pay for your boards.
 
@@ -85,17 +85,17 @@ If you can't source magnet mounts locally or via [Etsy](https://www.etsy.com/), 
 
 First, you can download the files available in the [PhobGCCv2-HW Github](https://github.com/PhobGCC/PhobGCCv2-HW/releases/tag/v2.0.5) in the releases section as shown below:
 
-![PHOB2_MAGNET_RELEASE](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob2_magnet_release.png?raw=true)
+![PHOB2_MAGNET_RELEASE](For_Makers/Phob_Ordering_Guide_Images/phob2_magnet_release.png?raw=true)
 
 Click "Order Now" on JLCPCB, make sure you are set to "3D Printing" tab, click "Add 3D Files", and upload the DH1H1_Magnet_Holder_JLCPCB.STL. Once the file is uploaded, you should see it render as shown below:
 
-![MAGNET_MOUNTS](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/dh1h1_mounts.PNG?raw=true)
+![MAGNET_MOUNTS](For_Makers/Phob_Ordering_Guide_Images/dh1h1_mounts.PNG?raw=true)
 
 The recommended settings are SLS Nylon. You then set the product description to Other -> Fastener as shown below
 
 **NOTE: QUANTITY 1 GETS YOU 10 MOUNTS, WHICH IS ENOUGH FOR 2.5 PHOBS. 2 GETS YOU 20 MOUNTS FOR 5 PHOBS. MAKE SURE YOU ORDER ENOUGH!**
 
-![MAGNET_SETTINGS](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/magnet_settings.PNG?raw=true)
+![MAGNET_SETTINGS](For_Makers/Phob_Ordering_Guide_Images/magnet_settings.PNG?raw=true)
 
 You can then click "Save To Cart" and pay for your mounts.
 
@@ -160,4 +160,4 @@ The GCC-specific Parts have a few different methods of acquisition
 
 # Assembly
 
-Once you have all the parts you need, follow the [build guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Build_Guide_2.0.md) to assemble your PhobGCC.
+Once you have all the parts you need, follow the [build guide](For_Makers/Build_Guide_2.0.md) to assemble your PhobGCC.

--- a/For_Makers/Phob2_Ordering_Guide.md
+++ b/For_Makers/Phob2_Ordering_Guide.md
@@ -60,11 +60,11 @@ If you don't or can't use OEM GCC Trigger paddles, you can order trigger paddles
 
 First, you can download the files available in the [PhobGCCv2-HW Github](https://github.com/PhobGCC/PhobGCCv2-HW/releases/tag/v2.0.5) in the releases section as shown below:
 
-![PHOB2_PADDLE_RELEASE](For_Makers/Phob_Ordering_Guide_Images/phob2_paddle_release.png?raw=true)
+![PHOB2_PADDLE_RELEASE](For_Makers/Phob_Ordering_Guide_Images/phob2_paddle_release.png)
 
 Click "Order Now" on JLCPCB, make sure you are set to "Standard PCB/PCBA" tab, click "Add Gerber File", and upload the Trigger_Paddle_Gerbers.zip. Once the files are uploaded, you should see the board process and then load in as shown below:
 
-![TRIGGER_BOARD](For_Makers/Phob_Ordering_Guide_Images/trigger_board.PNG?raw=true)
+![TRIGGER_BOARD](For_Makers/Phob_Ordering_Guide_Images/trigger_board.PNG)
 
 Once you've checked that the size is set to 9.7x41.72mm, you can progress with configuring it.
 The recommended settings are the defaults, setting your board quantity, setting "Different Design" to 2, and setting the Surface Finish to ENIG, as seen below:
@@ -73,7 +73,7 @@ The recommended settings are the defaults, setting your board quantity, setting 
 
 **NOTE2: SINCE THESE BOARDS ARE SO SMALL, THE QUANTITY DOESN'T CHANGE THE PRICE. WE SUGGEST ORDERING PLENTY SINCE ITS CHEAP. THE DIFFERENCE BETWEEN 20 AND 200 IS $18.**
 
-![TRIGGER_SETTINGS](For_Makers/Phob_Ordering_Guide_Images/trigger_settings.PNG?raw=true)
+![TRIGGER_SETTINGS](For_Makers/Phob_Ordering_Guide_Images/trigger_settings.PNG)
 
 You can then click "Save To Cart" and pay for your boards.
 
@@ -85,17 +85,17 @@ If you can't source magnet mounts locally or via [Etsy](https://www.etsy.com/), 
 
 First, you can download the files available in the [PhobGCCv2-HW Github](https://github.com/PhobGCC/PhobGCCv2-HW/releases/tag/v2.0.5) in the releases section as shown below:
 
-![PHOB2_MAGNET_RELEASE](For_Makers/Phob_Ordering_Guide_Images/phob2_magnet_release.png?raw=true)
+![PHOB2_MAGNET_RELEASE](For_Makers/Phob_Ordering_Guide_Images/phob2_magnet_release.png)
 
 Click "Order Now" on JLCPCB, make sure you are set to "3D Printing" tab, click "Add 3D Files", and upload the DH1H1_Magnet_Holder_JLCPCB.STL. Once the file is uploaded, you should see it render as shown below:
 
-![MAGNET_MOUNTS](For_Makers/Phob_Ordering_Guide_Images/dh1h1_mounts.PNG?raw=true)
+![MAGNET_MOUNTS](For_Makers/Phob_Ordering_Guide_Images/dh1h1_mounts.PNG)
 
 The recommended settings are SLS Nylon. You then set the product description to Other -> Fastener as shown below
 
 **NOTE: QUANTITY 1 GETS YOU 10 MOUNTS, WHICH IS ENOUGH FOR 2.5 PHOBS. 2 GETS YOU 20 MOUNTS FOR 5 PHOBS. MAKE SURE YOU ORDER ENOUGH!**
 
-![MAGNET_SETTINGS](For_Makers/Phob_Ordering_Guide_Images/magnet_settings.PNG?raw=true)
+![MAGNET_SETTINGS](For_Makers/Phob_Ordering_Guide_Images/magnet_settings.PNG)
 
 You can then click "Save To Cart" and pay for your mounts.
 

--- a/For_Makers/Phob_Ordering_Guide.md
+++ b/For_Makers/Phob_Ordering_Guide.md
@@ -33,16 +33,16 @@ There are two main ways to acquire a PhobGCC Board. The first way is if you inte
 
 First, you can download the files available in the [PhobGCC-HW Github](https://github.com/PhobGCC/PhobGCC-HW/releases) in the releases section as shown below:
 
-![PHOB_HW_FILES](For_Makers/Phob_Ordering_Guide_Images/phob_hw_files.PNG)
+![PHOB_HW_FILES](../For_Makers/Phob_Ordering_Guide_Images/phob_hw_files.PNG)
 
 Once you've extracted the files from the .zip, you should have three files. The Gerbers .zip, the bom.csv, and the top-pos.csv. Click "Order Now" on JLCPCB, click "Add Gerber File", and upload the Gerbers.zip. Once the files are uploaded, you should see the board load in as shown below:
 
-![PHOB_BOARD](For_Makers/Phob_Ordering_Guide_Images/phob_board.PNG)
+![PHOB_BOARD](../For_Makers/Phob_Ordering_Guide_Images/phob_board.PNG)
 
 Once you've checked that the size is set to 91.41x147.63mm, you can progress with configuring it.
 The recommended settings are the defaults, plus setting your board quantity, setting "Different Design" to 4, and setting the Surface Finish to ENIG, as seen below:
 
-![PHOB_SETTINGS](For_Makers/Phob_Ordering_Guide_Images/phob_settings.PNG)
+![PHOB_SETTINGS](../For_Makers/Phob_Ordering_Guide_Images/phob_settings.PNG)
 
 Scroll down to PCB Assembly and toggle it on the right.
 Select the top side and Economic PCBA Type (Not available for large orders or colors) as seen below.
@@ -50,14 +50,14 @@ If you choose to use Standard PCBA, JLC will have to add rails to the board, inc
 
 **NOTE: For large orders more than 50 boards or different colors, Standard Assembly is required. This attaches removable rails to the PCB at a significant extra cost.**
 
-![PHOB_ASM](For_Makers/Phob_Ordering_Guide_Images/phob_asm.PNG)
+![PHOB_ASM](../For_Makers/Phob_Ordering_Guide_Images/phob_asm.PNG)
 
 Click "Confirm" and then upload the bom.csv to the left and and the top-pos.csv to the right.
 Set the usage description to Research -> DIY and click "Next".
 The next screen should look like the following below with all 10 confirmed.
 If they are not confirmed, stop ordering and ask in the [PhobGCC Discord](https://discord.gg/yrpUu7mgzm).
 
-![PHOB_PARTS](For_Makers/Phob_Ordering_Guide_Images/phob_parts.PNG)
+![PHOB_PARTS](../For_Makers/Phob_Ordering_Guide_Images/phob_parts.PNG)
 
 After clicking "Next", you'll be presented with a view of the parts on the board.
 If this screen is corrupted, that's okay.

--- a/For_Makers/Phob_Ordering_Guide.md
+++ b/For_Makers/Phob_Ordering_Guide.md
@@ -33,16 +33,16 @@ There are two main ways to acquire a PhobGCC Board. The first way is if you inte
 
 First, you can download the files available in the [PhobGCC-HW Github](https://github.com/PhobGCC/PhobGCC-HW/releases) in the releases section as shown below:
 
-![PHOB_HW_FILES](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob_hw_files.PNG?raw=true)
+![PHOB_HW_FILES](For_Makers/Phob_Ordering_Guide_Images/phob_hw_files.PNG?raw=true)
 
 Once you've extracted the files from the .zip, you should have three files. The Gerbers .zip, the bom.csv, and the top-pos.csv. Click "Order Now" on JLCPCB, click "Add Gerber File", and upload the Gerbers.zip. Once the files are uploaded, you should see the board load in as shown below:
 
-![PHOB_BOARD](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob_board.PNG?raw=true)
+![PHOB_BOARD](For_Makers/Phob_Ordering_Guide_Images/phob_board.PNG?raw=true)
 
 Once you've checked that the size is set to 91.41x147.63mm, you can progress with configuring it.
 The recommended settings are the defaults, plus setting your board quantity, setting "Different Design" to 4, and setting the Surface Finish to ENIG, as seen below:
 
-![PHOB_SETTINGS](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob_settings.PNG?raw=true)
+![PHOB_SETTINGS](For_Makers/Phob_Ordering_Guide_Images/phob_settings.PNG?raw=true)
 
 Scroll down to PCB Assembly and toggle it on the right.
 Select the top side and Economic PCBA Type (Not available for large orders or colors) as seen below.
@@ -50,14 +50,14 @@ If you choose to use Standard PCBA, JLC will have to add rails to the board, inc
 
 **NOTE: For large orders more than 50 boards or different colors, Standard Assembly is required. This attaches removable rails to the PCB at a significant extra cost.**
 
-![PHOB_ASM](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob_asm.PNG?raw=true)
+![PHOB_ASM](For_Makers/Phob_Ordering_Guide_Images/phob_asm.PNG?raw=true)
 
 Click "Confirm" and then upload the bom.csv to the left and and the top-pos.csv to the right.
 Set the usage description to Research -> DIY and click "Next".
 The next screen should look like the following below with all 10 confirmed.
 If they are not confirmed, stop ordering and ask in the [PhobGCC Discord](https://discord.gg/yrpUu7mgzm).
 
-![PHOB_PARTS](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide_Images/phob_parts.PNG?raw=true)
+![PHOB_PARTS](For_Makers/Phob_Ordering_Guide_Images/phob_parts.PNG?raw=true)
 
 After clicking "Next", you'll be presented with a view of the parts on the board.
 If this screen is corrupted, that's okay.

--- a/For_Makers/Phob_Ordering_Guide.md
+++ b/For_Makers/Phob_Ordering_Guide.md
@@ -33,16 +33,16 @@ There are two main ways to acquire a PhobGCC Board. The first way is if you inte
 
 First, you can download the files available in the [PhobGCC-HW Github](https://github.com/PhobGCC/PhobGCC-HW/releases) in the releases section as shown below:
 
-![PHOB_HW_FILES](For_Makers/Phob_Ordering_Guide_Images/phob_hw_files.PNG?raw=true)
+![PHOB_HW_FILES](For_Makers/Phob_Ordering_Guide_Images/phob_hw_files.PNG)
 
 Once you've extracted the files from the .zip, you should have three files. The Gerbers .zip, the bom.csv, and the top-pos.csv. Click "Order Now" on JLCPCB, click "Add Gerber File", and upload the Gerbers.zip. Once the files are uploaded, you should see the board load in as shown below:
 
-![PHOB_BOARD](For_Makers/Phob_Ordering_Guide_Images/phob_board.PNG?raw=true)
+![PHOB_BOARD](For_Makers/Phob_Ordering_Guide_Images/phob_board.PNG)
 
 Once you've checked that the size is set to 91.41x147.63mm, you can progress with configuring it.
 The recommended settings are the defaults, plus setting your board quantity, setting "Different Design" to 4, and setting the Surface Finish to ENIG, as seen below:
 
-![PHOB_SETTINGS](For_Makers/Phob_Ordering_Guide_Images/phob_settings.PNG?raw=true)
+![PHOB_SETTINGS](For_Makers/Phob_Ordering_Guide_Images/phob_settings.PNG)
 
 Scroll down to PCB Assembly and toggle it on the right.
 Select the top side and Economic PCBA Type (Not available for large orders or colors) as seen below.
@@ -50,14 +50,14 @@ If you choose to use Standard PCBA, JLC will have to add rails to the board, inc
 
 **NOTE: For large orders more than 50 boards or different colors, Standard Assembly is required. This attaches removable rails to the PCB at a significant extra cost.**
 
-![PHOB_ASM](For_Makers/Phob_Ordering_Guide_Images/phob_asm.PNG?raw=true)
+![PHOB_ASM](For_Makers/Phob_Ordering_Guide_Images/phob_asm.PNG)
 
 Click "Confirm" and then upload the bom.csv to the left and and the top-pos.csv to the right.
 Set the usage description to Research -> DIY and click "Next".
 The next screen should look like the following below with all 10 confirmed.
 If they are not confirmed, stop ordering and ask in the [PhobGCC Discord](https://discord.gg/yrpUu7mgzm).
 
-![PHOB_PARTS](For_Makers/Phob_Ordering_Guide_Images/phob_parts.PNG?raw=true)
+![PHOB_PARTS](For_Makers/Phob_Ordering_Guide_Images/phob_parts.PNG)
 
 After clicking "Next", you'll be presented with a view of the parts on the board.
 If this screen is corrupted, that's okay.

--- a/For_Users/Extras_Guides/ESS_Adapter.md
+++ b/For_Users/Extras_Guides/ESS_Adapter.md
@@ -5,7 +5,7 @@ This is a guide for enabling ESS Adapter functionality for the PhobGCC.
 # Prerequisites
 
 As with all Extras, it must be built into the firmware and enabled by first
-following the [Extras Guide](For_Users/Phob_Extras_Guide.md).
+following the [Extras Guide](../../For_Users/Extras_Guides/Phob_Extras_Guide.md).
 
 # Overview
 

--- a/For_Users/Extras_Guides/ESS_Adapter.md
+++ b/For_Users/Extras_Guides/ESS_Adapter.md
@@ -5,7 +5,7 @@ This is a guide for enabling ESS Adapter functionality for the PhobGCC.
 # Prerequisites
 
 As with all Extras, it must be built into the firmware and enabled by first
-following the [Extras Guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Extras_Guide.md).
+following the [Extras Guide](For_Users/Phob_Extras_Guide.md).
 
 # Overview
 

--- a/For_Users/Extras_Guides/Phob_Extras_Guide.md
+++ b/For_Users/Extras_Guides/Phob_Extras_Guide.md
@@ -4,7 +4,7 @@ This is a guide to enabling Extras, community-created features that require to b
 
 # Prerequisites
 
-* The ability to flash the PhobGCC firmware normally by following the [Phob Programming Guide](For_Users/Phob_Programming_Guide.md).
+* The ability to flash the PhobGCC firmware normally by following the [Phob Programming Guide](../../For_Users/Phob_Programming_Guide.md).
 
 # Directional Configurations
 

--- a/For_Users/Extras_Guides/Phob_Extras_Guide.md
+++ b/For_Users/Extras_Guides/Phob_Extras_Guide.md
@@ -4,7 +4,7 @@ This is a guide to enabling Extras, community-created features that require to b
 
 # Prerequisites
 
-* The ability to flash the PhobGCC firmware normally by following the [Phob Programming Guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Programming_Guide.md).
+* The ability to flash the PhobGCC firmware normally by following the [Phob Programming Guide](For_Users/Phob_Programming_Guide.md).
 
 # Directional Configurations
 

--- a/For_Users/Phob2_Programming_Guide.md
+++ b/For_Users/Phob2_Programming_Guide.md
@@ -18,17 +18,17 @@ Carefully lift the board out of the shell and place the front shell down.
 
 Go to the [Releases](https://github.com/PhobGCC/PhobGCC-SW/releases) section of the PhobGCC-SW Github and download the latest available firmware. For the PhobGCC v2.0 board, you will want to download the .uf2 file as shown below:
 
-![PHOB2_FILES](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Programming_Guide_Images/phob2_files.PNG?raw=true)
+![PHOB2_FILES](For_Users/Phob_Programming_Guide_Images/phob2_files.PNG?raw=true)
 
 Move the .uf2 file to somewhere you can easily find it. Then unplug your controller from the adapter or console it is connected to, hold down the button on the front of the board, and plug the controller in as shown below:
 
 **NOTE: It is easier to plug in Micro-USB first and then hold the button and plug in USB-A on your computer**
 
-![PHOB2_PLUGIN](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Programming_Guide_Images/phob2_hold.jpg?raw=true)
+![PHOB2_PLUGIN](For_Users/Phob_Programming_Guide_Images/phob2_hold.jpg?raw=true)
 
 You should have it appear as a mass storage device, similar to a flashdrive. Drag the .uf2 file onto the controller and it'll transfer over the firmware and disconnect.
 
-![PHOB2_PLUGIN](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Programming_Guide_Images/Phob2_transfer.PNG?raw=true)
+![PHOB2_PLUGIN](For_Users/Phob_Programming_Guide_Images/Phob2_transfer.PNG?raw=true)
 
 Once this is complete, you can unplug your PhobGCC and reassemble the controller. Continue to the calibration guide.
 

--- a/For_Users/Phob2_Programming_Guide.md
+++ b/For_Users/Phob2_Programming_Guide.md
@@ -18,17 +18,17 @@ Carefully lift the board out of the shell and place the front shell down.
 
 Go to the [Releases](https://github.com/PhobGCC/PhobGCC-SW/releases) section of the PhobGCC-SW Github and download the latest available firmware. For the PhobGCC v2.0 board, you will want to download the .uf2 file as shown below:
 
-![PHOB2_FILES](For_Users/Phob_Programming_Guide_Images/phob2_files.PNG?raw=true)
+![PHOB2_FILES](For_Users/Phob_Programming_Guide_Images/phob2_files.PNG)
 
 Move the .uf2 file to somewhere you can easily find it. Then unplug your controller from the adapter or console it is connected to, hold down the button on the front of the board, and plug the controller in as shown below:
 
 **NOTE: It is easier to plug in Micro-USB first and then hold the button and plug in USB-A on your computer**
 
-![PHOB2_PLUGIN](For_Users/Phob_Programming_Guide_Images/phob2_hold.jpg?raw=true)
+![PHOB2_PLUGIN](For_Users/Phob_Programming_Guide_Images/phob2_hold.jpg)
 
 You should have it appear as a mass storage device, similar to a flashdrive. Drag the .uf2 file onto the controller and it'll transfer over the firmware and disconnect.
 
-![PHOB2_PLUGIN](For_Users/Phob_Programming_Guide_Images/Phob2_transfer.PNG?raw=true)
+![PHOB2_PLUGIN](For_Users/Phob_Programming_Guide_Images/Phob2_transfer.PNG)
 
 Once this is complete, you can unplug your PhobGCC and reassemble the controller. Continue to the calibration guide.
 

--- a/For_Users/Phob2_Programming_Guide.md
+++ b/For_Users/Phob2_Programming_Guide.md
@@ -18,17 +18,17 @@ Carefully lift the board out of the shell and place the front shell down.
 
 Go to the [Releases](https://github.com/PhobGCC/PhobGCC-SW/releases) section of the PhobGCC-SW Github and download the latest available firmware. For the PhobGCC v2.0 board, you will want to download the .uf2 file as shown below:
 
-![PHOB2_FILES](For_Users/Phob_Programming_Guide_Images/phob2_files.PNG)
+![PHOB2_FILES](../For_Users/Phob_Programming_Guide_Images/phob2_files.PNG)
 
 Move the .uf2 file to somewhere you can easily find it. Then unplug your controller from the adapter or console it is connected to, hold down the button on the front of the board, and plug the controller in as shown below:
 
 **NOTE: It is easier to plug in Micro-USB first and then hold the button and plug in USB-A on your computer**
 
-![PHOB2_PLUGIN](For_Users/Phob_Programming_Guide_Images/phob2_hold.jpg)
+![PHOB2_PLUGIN](../For_Users/Phob_Programming_Guide_Images/phob2_hold.jpg)
 
 You should have it appear as a mass storage device, similar to a flashdrive. Drag the .uf2 file onto the controller and it'll transfer over the firmware and disconnect.
 
-![PHOB2_PLUGIN](For_Users/Phob_Programming_Guide_Images/Phob2_transfer.PNG)
+![PHOB2_PLUGIN](../For_Users/Phob_Programming_Guide_Images/Phob2_transfer.PNG)
 
 Once this is complete, you can unplug your PhobGCC and reassemble the controller. Continue to the calibration guide.
 

--- a/For_Users/Phob_Buying_Guide.md
+++ b/For_Users/Phob_Buying_Guide.md
@@ -18,7 +18,7 @@ Which board version you have affects how you update the firmware.
 
 ### 1.0
 
-![PhobGCC 1.0](For_Users/Phob_Buying_Guide_Images/Phob1.0_TopView_cropped.jpeg?raw=true)
+![PhobGCC 1.0](For_Users/Phob_Buying_Guide_Images/Phob1.0_TopView_cropped.jpeg)
 
 * Very rare.
 * Has no rumble.
@@ -26,7 +26,7 @@ Which board version you have affects how you update the firmware.
 
 ### 1.1
 
-![PhobGCC 1.1 with Teensy 3.2](For_Users/Phob_Buying_Guide_Images/Phob1.1_TopView_cropped.jpeg?raw=true)
+![PhobGCC 1.1 with Teensy 3.2](For_Users/Phob_Buying_Guide_Images/Phob1.1_TopView_cropped.jpeg)
 
 * Somewhat common.
 * Has no rumble.
@@ -37,13 +37,13 @@ Which board version you have affects how you update the firmware.
   See photo below for what a Teensy 4 looks like on a PhobGCC 1.1.
   * Teensy 4.0 with Diode Fix: similar to above, but pins 7 and 8 on the Teensy may be shorted, or the diode next to the connector may be shorted.
 
-![PhobGCC 1.1 with Teensy 4 attached](For_Users/Phob_Buying_Guide_Images/Phob1.1Teensy4Bodge.jpg?raw=true)
+![PhobGCC 1.1 with Teensy 4 attached](For_Users/Phob_Buying_Guide_Images/Phob1.1Teensy4Bodge.jpg)
 
 ### 1.2:
 
-![PhobGCC 1.2.1](For_Users/Phob_Buying_Guide_Images/Phob1.2.1_TopView_Cropped.jpeg?raw=true)
+![PhobGCC 1.2.1](For_Users/Phob_Buying_Guide_Images/Phob1.2.1_TopView_Cropped.jpeg)
 
-![PhobGCC 1.2.2](For_Makers/BuildPics_1.2.2/CVAC1118_1lwoupq-output.jpg?raw=true)
+![PhobGCC 1.2.2](For_Makers/BuildPics_1.2.2/CVAC1118_1lwoupq-output.jpg)
 
 * Has rumble support.
 * Has mouse button support on the face buttons other than Start.
@@ -106,7 +106,7 @@ All solder joints should have the solder clearly sticking to both the component 
 
 The entire pad on the board should be wet out with solder, but there ideally should not be enough solder to form a convex ball.
 
-![Bad solder joint](For_Users/Phob_Buying_Guide_Images/badhalljoints_cropped.jpg?raw=true)
+![Bad solder joint](For_Users/Phob_Buying_Guide_Images/badhalljoints_cropped.jpg)
 
 This is an example of a solder joint that has poor contact with the board and caused undesirable stick behavior.
 

--- a/For_Users/Phob_Buying_Guide.md
+++ b/For_Users/Phob_Buying_Guide.md
@@ -18,7 +18,7 @@ Which board version you have affects how you update the firmware.
 
 ### 1.0
 
-![PhobGCC 1.0](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Buying_Guide_Images/Phob1.0_TopView_cropped.jpeg?raw=true)
+![PhobGCC 1.0](For_Users/Phob_Buying_Guide_Images/Phob1.0_TopView_cropped.jpeg?raw=true)
 
 * Very rare.
 * Has no rumble.
@@ -26,7 +26,7 @@ Which board version you have affects how you update the firmware.
 
 ### 1.1
 
-![PhobGCC 1.1 with Teensy 3.2](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Buying_Guide_Images/Phob1.1_TopView_cropped.jpeg?raw=true)
+![PhobGCC 1.1 with Teensy 3.2](For_Users/Phob_Buying_Guide_Images/Phob1.1_TopView_cropped.jpeg?raw=true)
 
 * Somewhat common.
 * Has no rumble.
@@ -37,13 +37,13 @@ Which board version you have affects how you update the firmware.
   See photo below for what a Teensy 4 looks like on a PhobGCC 1.1.
   * Teensy 4.0 with Diode Fix: similar to above, but pins 7 and 8 on the Teensy may be shorted, or the diode next to the connector may be shorted.
 
-![PhobGCC 1.1 with Teensy 4 attached](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Buying_Guide_Images/Phob1.1Teensy4Bodge.jpg?raw=true)
+![PhobGCC 1.1 with Teensy 4 attached](For_Users/Phob_Buying_Guide_Images/Phob1.1Teensy4Bodge.jpg?raw=true)
 
 ### 1.2:
 
-![PhobGCC 1.2.1](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Buying_Guide_Images/Phob1.2.1_TopView_Cropped.jpeg?raw=true)
+![PhobGCC 1.2.1](For_Users/Phob_Buying_Guide_Images/Phob1.2.1_TopView_Cropped.jpeg?raw=true)
 
-![PhobGCC 1.2.2](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_1.2.2/CVAC1118_1lwoupq-output.jpg?raw=true)
+![PhobGCC 1.2.2](For_Makers/BuildPics_1.2.2/CVAC1118_1lwoupq-output.jpg?raw=true)
 
 * Has rumble support.
 * Has mouse button support on the face buttons other than Start.
@@ -106,7 +106,7 @@ All solder joints should have the solder clearly sticking to both the component 
 
 The entire pad on the board should be wet out with solder, but there ideally should not be enough solder to form a convex ball.
 
-![Bad solder joint](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Buying_Guide_Images/badhalljoints_cropped.jpg?raw=true)
+![Bad solder joint](For_Users/Phob_Buying_Guide_Images/badhalljoints_cropped.jpg?raw=true)
 
 This is an example of a solder joint that has poor contact with the board and caused undesirable stick behavior.
 

--- a/For_Users/Phob_Buying_Guide.md
+++ b/For_Users/Phob_Buying_Guide.md
@@ -18,7 +18,7 @@ Which board version you have affects how you update the firmware.
 
 ### 1.0
 
-![PhobGCC 1.0](For_Users/Phob_Buying_Guide_Images/Phob1.0_TopView_cropped.jpeg)
+![PhobGCC 1.0](../For_Users/Phob_Buying_Guide_Images/Phob1.0_TopView_cropped.jpeg)
 
 * Very rare.
 * Has no rumble.
@@ -26,7 +26,7 @@ Which board version you have affects how you update the firmware.
 
 ### 1.1
 
-![PhobGCC 1.1 with Teensy 3.2](For_Users/Phob_Buying_Guide_Images/Phob1.1_TopView_cropped.jpeg)
+![PhobGCC 1.1 with Teensy 3.2](../For_Users/Phob_Buying_Guide_Images/Phob1.1_TopView_cropped.jpeg)
 
 * Somewhat common.
 * Has no rumble.
@@ -37,13 +37,13 @@ Which board version you have affects how you update the firmware.
   See photo below for what a Teensy 4 looks like on a PhobGCC 1.1.
   * Teensy 4.0 with Diode Fix: similar to above, but pins 7 and 8 on the Teensy may be shorted, or the diode next to the connector may be shorted.
 
-![PhobGCC 1.1 with Teensy 4 attached](For_Users/Phob_Buying_Guide_Images/Phob1.1Teensy4Bodge.jpg)
+![PhobGCC 1.1 with Teensy 4 attached](../For_Users/Phob_Buying_Guide_Images/Phob1.1Teensy4Bodge.jpg)
 
 ### 1.2:
 
-![PhobGCC 1.2.1](For_Users/Phob_Buying_Guide_Images/Phob1.2.1_TopView_Cropped.jpeg)
+![PhobGCC 1.2.1](../For_Users/Phob_Buying_Guide_Images/Phob1.2.1_TopView_Cropped.jpeg)
 
-![PhobGCC 1.2.2](For_Makers/BuildPics_1.2.2/CVAC1118_1lwoupq-output.jpg)
+![PhobGCC 1.2.2](../For_Makers/BuildPics_1.2.2/CVAC1118_1lwoupq-output.jpg)
 
 * Has rumble support.
 * Has mouse button support on the face buttons other than Start.
@@ -106,7 +106,7 @@ All solder joints should have the solder clearly sticking to both the component 
 
 The entire pad on the board should be wet out with solder, but there ideally should not be enough solder to form a convex ball.
 
-![Bad solder joint](For_Users/Phob_Buying_Guide_Images/badhalljoints_cropped.jpg)
+![Bad solder joint](../For_Users/Phob_Buying_Guide_Images/badhalljoints_cropped.jpg)
 
 This is an example of a solder joint that has poor contact with the board and caused undesirable stick behavior.
 

--- a/For_Users/Phob_Calibration_Guide_Latest.md
+++ b/For_Users/Phob_Calibration_Guide_Latest.md
@@ -1,6 +1,6 @@
 **NOTE: This is for firmware version 0.29.**
 
-For older versions, use the appropriate calibration document [from here](https://github.com/PhobGCC/PhobGCC-doc/blob/main/LEGACY.md).
+For older versions, use the appropriate calibration document [from here](LEGACY.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the `common/phobGCC.h` file to see the commands for that version as they may have changed.
 
@@ -56,7 +56,7 @@ If the controller is functioning normally, this has already been performed and y
   * For trigger offsets, which have a wide numerical range, it will only hold for 0.1 second.
 * If you're in Melee without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
 
 # Safe Mode Toggle - AXY+Start
 
@@ -73,8 +73,8 @@ If the controller is functioning normally, this has already been performed and y
   * The Y-axis will show the tens and ones digits. In this case, it would be 29.
   * The X-axis will show the thousands and hundreds digits. In this case, it would be 0.
 * You must use Smashscope to see this numerically.
-* If the controller doesn't show 29, then you need to reference an older configuration document [here](https://github.com/PhobGCC/PhobGCC-doc/blob/main/LEGACY.md).
-  * If it doesn't respond to this command at all, then it's likely the version is 0.23 or lower and you should [upgrade the controller firmware](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Programming_Guide.md).
+* If the controller doesn't show 29, then you need to reference an older configuration document [here](LEGACY.md).
+  * If it doesn't respond to this command at all, then it's likely the version is 0.23 or lower and you should [upgrade the controller firmware](For_Users/Phob_Programming_Guide.md).
 
 # Controller Reset - Hold ABZ then press Start
 
@@ -124,7 +124,7 @@ If the controller is functioning normally, this has already been performed and y
 
 **NOTE: If using Dolphin Smashscope, you MUST disable all Wii Remotes**
 
-![DISABLE_WII_REMOTES](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png?raw=true)
+![DISABLE_WII_REMOTES](For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png?raw=true)
 
 * Stick calibration has two phases: measurement and notch adjustment.
   * You **must** complete both measurement and notch adjustment for the setting to be saved.

--- a/For_Users/Phob_Calibration_Guide_Latest.md
+++ b/For_Users/Phob_Calibration_Guide_Latest.md
@@ -22,7 +22,7 @@ Navigate with the D-pad, select an item by pressing A, and back out by holding B
 
 Some menu pages are not complete yet, and on these you will be greeted by an "Under Construction" sign.
 
-Full PhobVision manual available [here](https://github.com/PhobGcc/PhobGCC-doc/blob/main/For_Users/Phobvision_Guide_Latest.md).
+Full PhobVision manual available [here](https://github.com/PhobGcc/PhobGCC-doc/blob/main/../For_Users/Phobvision_Guide_Latest.md).
 
 # Initial Setup
 
@@ -56,7 +56,7 @@ If the controller is functioning normally, this has already been performed and y
   * For trigger offsets, which have a wide numerical range, it will only hold for 0.1 second.
 * If you're in Melee without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
+![Sticks pointing up and to the right, triggers pressed](../For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 
@@ -74,7 +74,7 @@ If the controller is functioning normally, this has already been performed and y
   * The X-axis will show the thousands and hundreds digits. In this case, it would be 0.
 * You must use Smashscope to see this numerically.
 * If the controller doesn't show 29, then you need to reference an older configuration document [here](LEGACY.md).
-  * If it doesn't respond to this command at all, then it's likely the version is 0.23 or lower and you should [upgrade the controller firmware](For_Users/Phob_Programming_Guide.md).
+  * If it doesn't respond to this command at all, then it's likely the version is 0.23 or lower and you should [upgrade the controller firmware](../For_Users/Phob_Programming_Guide.md).
 
 # Controller Reset - Hold ABZ then press Start
 
@@ -124,7 +124,7 @@ If the controller is functioning normally, this has already been performed and y
 
 **NOTE: If using Dolphin Smashscope, you MUST disable all Wii Remotes**
 
-![DISABLE_WII_REMOTES](For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png)
+![DISABLE_WII_REMOTES](../For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png)
 
 * Stick calibration has two phases: measurement and notch adjustment.
   * You **must** complete both measurement and notch adjustment for the setting to be saved.

--- a/For_Users/Phob_Calibration_Guide_Latest.md
+++ b/For_Users/Phob_Calibration_Guide_Latest.md
@@ -56,7 +56,7 @@ If the controller is functioning normally, this has already been performed and y
   * For trigger offsets, which have a wide numerical range, it will only hold for 0.1 second.
 * If you're in Melee without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 
@@ -124,7 +124,7 @@ If the controller is functioning normally, this has already been performed and y
 
 **NOTE: If using Dolphin Smashscope, you MUST disable all Wii Remotes**
 
-![DISABLE_WII_REMOTES](For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png?raw=true)
+![DISABLE_WII_REMOTES](For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png)
 
 * Stick calibration has two phases: measurement and notch adjustment.
   * You **must** complete both measurement and notch adjustment for the setting to be saved.

--- a/For_Users/Phob_Calibration_Guide_v0.20.md
+++ b/For_Users/Phob_Calibration_Guide_v0.20.md
@@ -1,4 +1,4 @@
-**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](For_Users/Phob_Calibration_Guide_v0.28.md)**
+**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](../For_Users/Phob_Calibration_Guide_v0.28.md)**
 
 **NOTE: This is for firmware version 0.20.**
 
@@ -21,7 +21,7 @@ An alternative is Uncle Punch Training Mode 3.0. In the Training Lab menu, under
 * Every time you give the PhobGCC a command, except for during the stick calibration process, the analog and c-stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
+![Sticks pointing up and to the right, triggers pressed](../For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.20.md
+++ b/For_Users/Phob_Calibration_Guide_v0.20.md
@@ -1,4 +1,4 @@
-**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.28.md)**
+**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](For_Users/Phob_Calibration_Guide_v0.28.md)**
 
 **NOTE: This is for firmware version 0.20.**
 
@@ -21,7 +21,7 @@ An alternative is Uncle Punch Training Mode 3.0. In the Training Lab menu, under
 * Every time you give the PhobGCC a command, except for during the stick calibration process, the analog and c-stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-stick.
 
-![Sticks pointing up and to the right, triggers pressed](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.20.md
+++ b/For_Users/Phob_Calibration_Guide_v0.20.md
@@ -21,7 +21,7 @@ An alternative is Uncle Punch Training Mode 3.0. In the Training Lab menu, under
 * Every time you give the PhobGCC a command, except for during the stick calibration process, the analog and c-stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.21.md
+++ b/For_Users/Phob_Calibration_Guide_v0.21.md
@@ -39,7 +39,7 @@ We're not quite sure why.
 * Every time you give the PhobGCC a command, except for during the stick calibration process, the analog and c-stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.21.md
+++ b/For_Users/Phob_Calibration_Guide_v0.21.md
@@ -1,8 +1,8 @@
-**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](For_Users/Phob_Calibration_Guide_v0.28.md)**
+**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](../For_Users/Phob_Calibration_Guide_v0.28.md)**
 
 **NOTE: This is for firmware version 0.21.**
 
-For Version 0.20, use [this document](For_Users/Phob_Calibration_Guide_v0.20.md).
+For Version 0.20, use [this document](../For_Users/Phob_Calibration_Guide_v0.20.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the PhobGCC.ino file to see the commands for that version as they may have changed.
 
@@ -39,7 +39,7 @@ We're not quite sure why.
 * Every time you give the PhobGCC a command, except for during the stick calibration process, the analog and c-stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
+![Sticks pointing up and to the right, triggers pressed](../For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.21.md
+++ b/For_Users/Phob_Calibration_Guide_v0.21.md
@@ -1,8 +1,8 @@
-**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.28.md)**
+**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](For_Users/Phob_Calibration_Guide_v0.28.md)**
 
 **NOTE: This is for firmware version 0.21.**
 
-For Version 0.20, use [this document](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.20.md).
+For Version 0.20, use [this document](For_Users/Phob_Calibration_Guide_v0.20.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the PhobGCC.ino file to see the commands for that version as they may have changed.
 
@@ -39,7 +39,7 @@ We're not quite sure why.
 * Every time you give the PhobGCC a command, except for during the stick calibration process, the analog and c-stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-stick.
 
-![Sticks pointing up and to the right, triggers pressed](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.22.md
+++ b/For_Users/Phob_Calibration_Guide_v0.22.md
@@ -39,7 +39,7 @@ We're not quite sure why.
 * Every time you give the PhobGCC a command, except for during the stick calibration process, the analog and c-stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.22.md
+++ b/For_Users/Phob_Calibration_Guide_v0.22.md
@@ -1,8 +1,8 @@
-**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](For_Users/Phob_Calibration_Guide_v0.28.md)**
+**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](../For_Users/Phob_Calibration_Guide_v0.28.md)**
 
 **NOTE: This is for firmware version 0.22.**
 
-For Version 0.21, use [this document](For_Users/Phob_Calibration_Guide_v0.21.md).
+For Version 0.21, use [this document](../For_Users/Phob_Calibration_Guide_v0.21.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the PhobGCC.ino file to see the commands for that version as they may have changed.
 
@@ -39,7 +39,7 @@ We're not quite sure why.
 * Every time you give the PhobGCC a command, except for during the stick calibration process, the analog and c-stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
+![Sticks pointing up and to the right, triggers pressed](../For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.22.md
+++ b/For_Users/Phob_Calibration_Guide_v0.22.md
@@ -1,8 +1,8 @@
-**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.28.md)**
+**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](For_Users/Phob_Calibration_Guide_v0.28.md)**
 
 **NOTE: This is for firmware version 0.22.**
 
-For Version 0.21, use [this document](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.21.md).
+For Version 0.21, use [this document](For_Users/Phob_Calibration_Guide_v0.21.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the PhobGCC.ino file to see the commands for that version as they may have changed.
 
@@ -39,7 +39,7 @@ We're not quite sure why.
 * Every time you give the PhobGCC a command, except for during the stick calibration process, the analog and c-stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.23.md
+++ b/For_Users/Phob_Calibration_Guide_v0.23.md
@@ -1,8 +1,8 @@
-**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](For_Users/Phob_Calibration_Guide_v0.28.md)**
+**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](../For_Users/Phob_Calibration_Guide_v0.28.md)**
 
 **NOTE: This is for firmware version 0.23.**
 
-For Version 0.22, use [this document](For_Users/Phob_Calibration_Guide_v0.22.md).
+For Version 0.22, use [this document](../For_Users/Phob_Calibration_Guide_v0.22.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the PhobGCC.ino file to see the commands for that version as they may have changed.
 
@@ -42,7 +42,7 @@ We're not quite sure why.
 * Every time you give the PhobGCC a command, except for during the stick calibration process, the Analog Stick and C-Stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
+![Sticks pointing up and to the right, triggers pressed](../For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.23.md
+++ b/For_Users/Phob_Calibration_Guide_v0.23.md
@@ -42,7 +42,7 @@ We're not quite sure why.
 * Every time you give the PhobGCC a command, except for during the stick calibration process, the Analog Stick and C-Stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.23.md
+++ b/For_Users/Phob_Calibration_Guide_v0.23.md
@@ -1,8 +1,8 @@
-**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.28.md)**
+**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](For_Users/Phob_Calibration_Guide_v0.28.md)**
 
 **NOTE: This is for firmware version 0.23.**
 
-For Version 0.22, use [this document](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.22.md).
+For Version 0.22, use [this document](For_Users/Phob_Calibration_Guide_v0.22.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the PhobGCC.ino file to see the commands for that version as they may have changed.
 
@@ -42,7 +42,7 @@ We're not quite sure why.
 * Every time you give the PhobGCC a command, except for during the stick calibration process, the Analog Stick and C-Stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.24.md
+++ b/For_Users/Phob_Calibration_Guide_v0.24.md
@@ -1,8 +1,8 @@
-**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.28.md)**
+**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](For_Users/Phob_Calibration_Guide_v0.28.md)**
 
 **NOTE: This is for firmware version 0.24.**
 
-For Version 0.23, use [this document](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.23.md).
+For Version 0.23, use [this document](For_Users/Phob_Calibration_Guide_v0.23.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the PhobGCC.ino file to see the commands for that version as they may have changed.
 
@@ -43,7 +43,7 @@ If you don't unplug and replug the controller between the first time calibrating
 * Most of the time, when you give the PhobGCC a command, the Analog Stick and C-Stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.24.md
+++ b/For_Users/Phob_Calibration_Guide_v0.24.md
@@ -1,8 +1,8 @@
-**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](For_Users/Phob_Calibration_Guide_v0.28.md)**
+**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](../For_Users/Phob_Calibration_Guide_v0.28.md)**
 
 **NOTE: This is for firmware version 0.24.**
 
-For Version 0.23, use [this document](For_Users/Phob_Calibration_Guide_v0.23.md).
+For Version 0.23, use [this document](../For_Users/Phob_Calibration_Guide_v0.23.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the PhobGCC.ino file to see the commands for that version as they may have changed.
 
@@ -43,7 +43,7 @@ If you don't unplug and replug the controller between the first time calibrating
 * Most of the time, when you give the PhobGCC a command, the Analog Stick and C-Stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
+![Sticks pointing up and to the right, triggers pressed](../For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.24.md
+++ b/For_Users/Phob_Calibration_Guide_v0.24.md
@@ -43,7 +43,7 @@ If you don't unplug and replug the controller between the first time calibrating
 * Most of the time, when you give the PhobGCC a command, the Analog Stick and C-Stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.25.md
+++ b/For_Users/Phob_Calibration_Guide_v0.25.md
@@ -1,8 +1,8 @@
-**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](For_Users/Phob_Calibration_Guide_v0.28.md)**
+**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](../For_Users/Phob_Calibration_Guide_v0.28.md)**
 
 **NOTE: This is for firmware version 0.25.**
 
-For Version 0.24, use [this document](For_Users/Phob_Calibration_Guide_v0.24.md).
+For Version 0.24, use [this document](../For_Users/Phob_Calibration_Guide_v0.24.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the PhobGCC.ino file to see the commands for that version as they may have changed.
 
@@ -40,7 +40,7 @@ You do not need to do this otherwise.
 * Most of the time, when you give the PhobGCC a command, the Analog Stick and C-Stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
+![Sticks pointing up and to the right, triggers pressed](../For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.25.md
+++ b/For_Users/Phob_Calibration_Guide_v0.25.md
@@ -40,7 +40,7 @@ You do not need to do this otherwise.
 * Most of the time, when you give the PhobGCC a command, the Analog Stick and C-Stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.25.md
+++ b/For_Users/Phob_Calibration_Guide_v0.25.md
@@ -1,8 +1,8 @@
-**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.28.md)**
+**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](For_Users/Phob_Calibration_Guide_v0.28.md)**
 
 **NOTE: This is for firmware version 0.25.**
 
-For Version 0.24, use [this document](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.24.md).
+For Version 0.24, use [this document](For_Users/Phob_Calibration_Guide_v0.24.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the PhobGCC.ino file to see the commands for that version as they may have changed.
 
@@ -40,7 +40,7 @@ You do not need to do this otherwise.
 * Most of the time, when you give the PhobGCC a command, the Analog Stick and C-Stick will freeze pointing to the top right for 2 seconds.
 * If you're in game without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.26.md
+++ b/For_Users/Phob_Calibration_Guide_v0.26.md
@@ -43,7 +43,7 @@ You do not need to do this otherwise.
   * For trigger offsets, which have a wide numerical range, it will only hold for 0.1 second.
 * If you're in Melee without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.26.md
+++ b/For_Users/Phob_Calibration_Guide_v0.26.md
@@ -1,8 +1,8 @@
-**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.28.md)**
+**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](For_Users/Phob_Calibration_Guide_v0.28.md)**
 
 **NOTE: This is for firmware version 0.26.**
 
-For Version 0.25, use [this document](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.25.md).
+For Version 0.25, use [this document](For_Users/Phob_Calibration_Guide_v0.25.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the `common/phobGCC.h` file to see the commands for that version as they may have changed.
 
@@ -43,7 +43,7 @@ You do not need to do this otherwise.
   * For trigger offsets, which have a wide numerical range, it will only hold for 0.1 second.
 * If you're in Melee without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.26.md
+++ b/For_Users/Phob_Calibration_Guide_v0.26.md
@@ -1,8 +1,8 @@
-**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](For_Users/Phob_Calibration_Guide_v0.28.md)**
+**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](../For_Users/Phob_Calibration_Guide_v0.28.md)**
 
 **NOTE: This is for firmware version 0.26.**
 
-For Version 0.25, use [this document](For_Users/Phob_Calibration_Guide_v0.25.md).
+For Version 0.25, use [this document](../For_Users/Phob_Calibration_Guide_v0.25.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the `common/phobGCC.h` file to see the commands for that version as they may have changed.
 
@@ -43,7 +43,7 @@ You do not need to do this otherwise.
   * For trigger offsets, which have a wide numerical range, it will only hold for 0.1 second.
 * If you're in Melee without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
+![Sticks pointing up and to the right, triggers pressed](../For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 

--- a/For_Users/Phob_Calibration_Guide_v0.27.md
+++ b/For_Users/Phob_Calibration_Guide_v0.27.md
@@ -1,8 +1,8 @@
-**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.28.md)**
+**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](For_Users/Phob_Calibration_Guide_v0.28.md)**
 
 **NOTE: This is for firmware version 0.27.**
 
-For Version 0.26, use [this document](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.26.md).
+For Version 0.26, use [this document](For_Users/Phob_Calibration_Guide_v0.26.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the `common/phobGCC.h` file to see the commands for that version as they may have changed.
 
@@ -45,7 +45,7 @@ If the controller is functioning normally, this has already been performed and y
   * For trigger offsets, which have a wide numerical range, it will only hold for 0.1 second.
 * If you're in Melee without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
 
 # Safe Mode Toggle - AXY+Start
 
@@ -62,8 +62,8 @@ If the controller is functioning normally, this has already been performed and y
   * The Y-axis will show the tens and ones digits. In this case, it would be 27.
   * The X-axis will show the thousands and hundreds digits. In this case, it would be 0.
 * You must use Smashscope to see this numerically.
-* If the controller doesn't show 27, then you need to reference an older configuration document [here](https://github.com/PhobGCC/PhobGCC-doc/blob/main/LEGACY.md).
-  * If it doesn't respond to this command at all, then it's likely the version is 0.23 or lower and you should [upgrade the controller firmware](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Programming_Guide.md).
+* If the controller doesn't show 27, then you need to reference an older configuration document [here](LEGACY.md).
+  * If it doesn't respond to this command at all, then it's likely the version is 0.23 or lower and you should [upgrade the controller firmware](For_Users/Phob_Programming_Guide.md).
 
 # Controller Reset - Hold ABZ then press Start
 
@@ -101,7 +101,7 @@ If the controller is functioning normally, this has already been performed and y
 
 **NOTE: If using Dolphin Smashscope, you MUST disable all Wii Remotes**
 
-![DISABLE_WII_REMOTES](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png?raw=true)
+![DISABLE_WII_REMOTES](For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png?raw=true)
 
 * Stick calibration has two phases: measurement and notch adjustment.
   * You **must** complete both measurement and notch adjustment for the setting to be saved.

--- a/For_Users/Phob_Calibration_Guide_v0.27.md
+++ b/For_Users/Phob_Calibration_Guide_v0.27.md
@@ -1,8 +1,8 @@
-**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](For_Users/Phob_Calibration_Guide_v0.28.md)**
+**THIS IS LEGACY FIRMWARE! PLEASE UPDATE TO THE [LATEST!](../For_Users/Phob_Calibration_Guide_v0.28.md)**
 
 **NOTE: This is for firmware version 0.27.**
 
-For Version 0.26, use [this document](For_Users/Phob_Calibration_Guide_v0.26.md).
+For Version 0.26, use [this document](../For_Users/Phob_Calibration_Guide_v0.26.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the `common/phobGCC.h` file to see the commands for that version as they may have changed.
 
@@ -45,7 +45,7 @@ If the controller is functioning normally, this has already been performed and y
   * For trigger offsets, which have a wide numerical range, it will only hold for 0.1 second.
 * If you're in Melee without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
+![Sticks pointing up and to the right, triggers pressed](../For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 
@@ -63,7 +63,7 @@ If the controller is functioning normally, this has already been performed and y
   * The X-axis will show the thousands and hundreds digits. In this case, it would be 0.
 * You must use Smashscope to see this numerically.
 * If the controller doesn't show 27, then you need to reference an older configuration document [here](LEGACY.md).
-  * If it doesn't respond to this command at all, then it's likely the version is 0.23 or lower and you should [upgrade the controller firmware](For_Users/Phob_Programming_Guide.md).
+  * If it doesn't respond to this command at all, then it's likely the version is 0.23 or lower and you should [upgrade the controller firmware](../For_Users/Phob_Programming_Guide.md).
 
 # Controller Reset - Hold ABZ then press Start
 
@@ -101,7 +101,7 @@ If the controller is functioning normally, this has already been performed and y
 
 **NOTE: If using Dolphin Smashscope, you MUST disable all Wii Remotes**
 
-![DISABLE_WII_REMOTES](For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png)
+![DISABLE_WII_REMOTES](../For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png)
 
 * Stick calibration has two phases: measurement and notch adjustment.
   * You **must** complete both measurement and notch adjustment for the setting to be saved.

--- a/For_Users/Phob_Calibration_Guide_v0.27.md
+++ b/For_Users/Phob_Calibration_Guide_v0.27.md
@@ -45,7 +45,7 @@ If the controller is functioning normally, this has already been performed and y
   * For trigger offsets, which have a wide numerical range, it will only hold for 0.1 second.
 * If you're in Melee without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 
@@ -101,7 +101,7 @@ If the controller is functioning normally, this has already been performed and y
 
 **NOTE: If using Dolphin Smashscope, you MUST disable all Wii Remotes**
 
-![DISABLE_WII_REMOTES](For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png?raw=true)
+![DISABLE_WII_REMOTES](For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png)
 
 * Stick calibration has two phases: measurement and notch adjustment.
   * You **must** complete both measurement and notch adjustment for the setting to be saved.

--- a/For_Users/Phob_Calibration_Guide_v0.28.md
+++ b/For_Users/Phob_Calibration_Guide_v0.28.md
@@ -55,7 +55,7 @@ If the controller is functioning normally, this has already been performed and y
   * For trigger offsets, which have a wide numerical range, it will only hold for 0.1 second.
 * If you're in Melee without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 
@@ -111,7 +111,7 @@ If the controller is functioning normally, this has already been performed and y
 
 **NOTE: If using Dolphin Smashscope, you MUST disable all Wii Remotes**
 
-![DISABLE_WII_REMOTES](For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png?raw=true)
+![DISABLE_WII_REMOTES](For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png)
 
 * Stick calibration has two phases: measurement and notch adjustment.
   * You **must** complete both measurement and notch adjustment for the setting to be saved.

--- a/For_Users/Phob_Calibration_Guide_v0.28.md
+++ b/For_Users/Phob_Calibration_Guide_v0.28.md
@@ -1,6 +1,6 @@
 **NOTE: This is for firmware version 0.28.**
 
-For Version 0.27, use [this document](For_Users/Phob_Calibration_Guide_v0.27.md).
+For Version 0.27, use [this document](../For_Users/Phob_Calibration_Guide_v0.27.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the `common/phobGCC.h` file to see the commands for that version as they may have changed.
 
@@ -55,7 +55,7 @@ If the controller is functioning normally, this has already been performed and y
   * For trigger offsets, which have a wide numerical range, it will only hold for 0.1 second.
 * If you're in Melee without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
+![Sticks pointing up and to the right, triggers pressed](../For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png)
 
 # Safe Mode Toggle - AXY+Start
 
@@ -73,7 +73,7 @@ If the controller is functioning normally, this has already been performed and y
   * The X-axis will show the thousands and hundreds digits. In this case, it would be 0.
 * You must use Smashscope to see this numerically.
 * If the controller doesn't show 28, then you need to reference an older configuration document [here](LEGACY.md).
-  * If it doesn't respond to this command at all, then it's likely the version is 0.23 or lower and you should [upgrade the controller firmware](For_Users/Phob_Programming_Guide.md).
+  * If it doesn't respond to this command at all, then it's likely the version is 0.23 or lower and you should [upgrade the controller firmware](../For_Users/Phob_Programming_Guide.md).
 
 # Controller Reset - Hold ABZ then press Start
 
@@ -111,7 +111,7 @@ If the controller is functioning normally, this has already been performed and y
 
 **NOTE: If using Dolphin Smashscope, you MUST disable all Wii Remotes**
 
-![DISABLE_WII_REMOTES](For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png)
+![DISABLE_WII_REMOTES](../For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png)
 
 * Stick calibration has two phases: measurement and notch adjustment.
   * You **must** complete both measurement and notch adjustment for the setting to be saved.

--- a/For_Users/Phob_Calibration_Guide_v0.28.md
+++ b/For_Users/Phob_Calibration_Guide_v0.28.md
@@ -1,6 +1,6 @@
 **NOTE: This is for firmware version 0.28.**
 
-For Version 0.27, use [this document](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.27.md).
+For Version 0.27, use [this document](For_Users/Phob_Calibration_Guide_v0.27.md).
 
 For later development versions of the software that have not yet been released, search for “Current Commands List” in the `common/phobGCC.h` file to see the commands for that version as they may have changed.
 
@@ -55,7 +55,7 @@ If the controller is functioning normally, this has already been performed and y
   * For trigger offsets, which have a wide numerical range, it will only hold for 0.1 second.
 * If you're in Melee without input visualization tools, you will see your character roll to the right to indicate this, or you'll see the menu tilt due to the C-Stick.
 
-![Sticks pointing up and to the right, triggers pressed](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
+![Sticks pointing up and to the right, triggers pressed](For_Users/Phob_Calibration_Guide_v0.20_Images/FreezeSticks.png?raw=true)
 
 # Safe Mode Toggle - AXY+Start
 
@@ -72,8 +72,8 @@ If the controller is functioning normally, this has already been performed and y
   * The Y-axis will show the tens and ones digits. In this case, it would be 28.
   * The X-axis will show the thousands and hundreds digits. In this case, it would be 0.
 * You must use Smashscope to see this numerically.
-* If the controller doesn't show 28, then you need to reference an older configuration document [here](https://github.com/PhobGCC/PhobGCC-doc/blob/main/LEGACY.md).
-  * If it doesn't respond to this command at all, then it's likely the version is 0.23 or lower and you should [upgrade the controller firmware](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Programming_Guide.md).
+* If the controller doesn't show 28, then you need to reference an older configuration document [here](LEGACY.md).
+  * If it doesn't respond to this command at all, then it's likely the version is 0.23 or lower and you should [upgrade the controller firmware](For_Users/Phob_Programming_Guide.md).
 
 # Controller Reset - Hold ABZ then press Start
 
@@ -111,7 +111,7 @@ If the controller is functioning normally, this has already been performed and y
 
 **NOTE: If using Dolphin Smashscope, you MUST disable all Wii Remotes**
 
-![DISABLE_WII_REMOTES](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png?raw=true)
+![DISABLE_WII_REMOTES](For_Users/Phob_Calibration_Guide_v0.20_Images/disableWiiRemotes.png?raw=true)
 
 * Stick calibration has two phases: measurement and notch adjustment.
   * You **must** complete both measurement and notch adjustment for the setting to be saved.

--- a/For_Users/Phob_Programming_Guide.md
+++ b/For_Users/Phob_Programming_Guide.md
@@ -28,7 +28,7 @@ Upon first run, it may ask about internet access and to install the USB Driver.
 These are required in order to program the PhobGCC.
 Once the IDE is installed, you can go to the 'Tools' drop-down and select 'Manage Libraries...'.
 
-![Libraries](For_Users/Phob_Programming_Guide_Images/manage_libraries.png)
+![Libraries](../For_Users/Phob_Programming_Guide_Images/manage_libraries.png)
 
 You'll want to search (what is in the single quotes) and install the following:
 * 'curveFitting' by Rotario
@@ -41,15 +41,15 @@ You may need to resize the left panel in order to see the Install button.
 
 Next you'll want to go to the 'File' drop-down and click on 'Preferences...' as seen below:
 
-![Preferences](For_Users/Phob_Programming_Guide_Images/preferences.png)
+![Preferences](../For_Users/Phob_Programming_Guide_Images/preferences.png)
 
 and in the 'Additional board manager URLs' section, you'll want to paste in `https://www.pjrc.com/teensy/package_teensy_index.json`. You'll also want to enable the "Show files inside Sketches" checkbox as shown below:
 
-![Preferences_2](For_Users/Phob_Programming_Guide_Images/preferences_2.png)
+![Preferences_2](../For_Users/Phob_Programming_Guide_Images/preferences_2.png)
 
 Next you'll want to go to the 'Tools' drop-down, in the 'Board' section, Click on 'Board Manager' as seen below:
 
-![Boards](For_Users/Phob_Programming_Guide_Images/board_manager.png)
+![Boards](../For_Users/Phob_Programming_Guide_Images/board_manager.png)
 
 And search for and install 'teensy' by Paul Stoffregen.
 
@@ -62,7 +62,7 @@ Open the `PhobGCC.ino` file that is inside the `PhobGCC` folder in Arduino IDE.
 Inside the subfolder `common`, find the document `phobGCC.h` and open it in a text editor (Notepad, if you have nothing else).
 Look near the top of the document for the following section:
 
-![Versions](For_Users/Phob_Programming_Guide_Images/phob_versions_v0.26.png)
+![Versions](../For_Users/Phob_Programming_Guide_Images/phob_versions_v0.26.png)
 
 Remove the `//` (NOT THE `#`) at the start of the line which contains your board version, and save the file.
 **Only uncomment one line.**

--- a/For_Users/Phob_Programming_Guide.md
+++ b/For_Users/Phob_Programming_Guide.md
@@ -28,7 +28,7 @@ Upon first run, it may ask about internet access and to install the USB Driver.
 These are required in order to program the PhobGCC.
 Once the IDE is installed, you can go to the 'Tools' drop-down and select 'Manage Libraries...'.
 
-![Libraries](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Programming_Guide_Images/manage_libraries.png?raw=true)
+![Libraries](For_Users/Phob_Programming_Guide_Images/manage_libraries.png?raw=true)
 
 You'll want to search (what is in the single quotes) and install the following:
 * 'curveFitting' by Rotario
@@ -41,15 +41,15 @@ You may need to resize the left panel in order to see the Install button.
 
 Next you'll want to go to the 'File' drop-down and click on 'Preferences...' as seen below:
 
-![Preferences](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Programming_Guide_Images/preferences.png?raw=true)
+![Preferences](For_Users/Phob_Programming_Guide_Images/preferences.png?raw=true)
 
 and in the 'Additional board manager URLs' section, you'll want to paste in `https://www.pjrc.com/teensy/package_teensy_index.json`. You'll also want to enable the "Show files inside Sketches" checkbox as shown below:
 
-![Preferences_2](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Programming_Guide_Images/preferences_2.png?raw=true)
+![Preferences_2](For_Users/Phob_Programming_Guide_Images/preferences_2.png?raw=true)
 
 Next you'll want to go to the 'Tools' drop-down, in the 'Board' section, Click on 'Board Manager' as seen below:
 
-![Boards](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Programming_Guide_Images/board_manager.png?raw=true)
+![Boards](For_Users/Phob_Programming_Guide_Images/board_manager.png?raw=true)
 
 And search for and install 'teensy' by Paul Stoffregen.
 
@@ -62,7 +62,7 @@ Open the `PhobGCC.ino` file that is inside the `PhobGCC` folder in Arduino IDE.
 Inside the subfolder `common`, find the document `phobGCC.h` and open it in a text editor (Notepad, if you have nothing else).
 Look near the top of the document for the following section:
 
-![Versions](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Programming_Guide_Images/phob_versions_v0.26.png?raw=true)
+![Versions](For_Users/Phob_Programming_Guide_Images/phob_versions_v0.26.png?raw=true)
 
 Remove the `//` (NOT THE `#`) at the start of the line which contains your board version, and save the file.
 **Only uncomment one line.**

--- a/For_Users/Phob_Programming_Guide.md
+++ b/For_Users/Phob_Programming_Guide.md
@@ -28,7 +28,7 @@ Upon first run, it may ask about internet access and to install the USB Driver.
 These are required in order to program the PhobGCC.
 Once the IDE is installed, you can go to the 'Tools' drop-down and select 'Manage Libraries...'.
 
-![Libraries](For_Users/Phob_Programming_Guide_Images/manage_libraries.png?raw=true)
+![Libraries](For_Users/Phob_Programming_Guide_Images/manage_libraries.png)
 
 You'll want to search (what is in the single quotes) and install the following:
 * 'curveFitting' by Rotario
@@ -41,15 +41,15 @@ You may need to resize the left panel in order to see the Install button.
 
 Next you'll want to go to the 'File' drop-down and click on 'Preferences...' as seen below:
 
-![Preferences](For_Users/Phob_Programming_Guide_Images/preferences.png?raw=true)
+![Preferences](For_Users/Phob_Programming_Guide_Images/preferences.png)
 
 and in the 'Additional board manager URLs' section, you'll want to paste in `https://www.pjrc.com/teensy/package_teensy_index.json`. You'll also want to enable the "Show files inside Sketches" checkbox as shown below:
 
-![Preferences_2](For_Users/Phob_Programming_Guide_Images/preferences_2.png?raw=true)
+![Preferences_2](For_Users/Phob_Programming_Guide_Images/preferences_2.png)
 
 Next you'll want to go to the 'Tools' drop-down, in the 'Board' section, Click on 'Board Manager' as seen below:
 
-![Boards](For_Users/Phob_Programming_Guide_Images/board_manager.png?raw=true)
+![Boards](For_Users/Phob_Programming_Guide_Images/board_manager.png)
 
 And search for and install 'teensy' by Paul Stoffregen.
 
@@ -62,7 +62,7 @@ Open the `PhobGCC.ino` file that is inside the `PhobGCC` folder in Arduino IDE.
 Inside the subfolder `common`, find the document `phobGCC.h` and open it in a text editor (Notepad, if you have nothing else).
 Look near the top of the document for the following section:
 
-![Versions](For_Users/Phob_Programming_Guide_Images/phob_versions_v0.26.png?raw=true)
+![Versions](For_Users/Phob_Programming_Guide_Images/phob_versions_v0.26.png)
 
 Remove the `//` (NOT THE `#`) at the start of the line which contains your board version, and save the file.
 **Only uncomment one line.**

--- a/For_Users/Phobvision_Guide_Latest.md
+++ b/For_Users/Phobvision_Guide_Latest.md
@@ -4,7 +4,7 @@ NOTE: This is for PhobGCC 2 with firmware version 0.29.
 
 PhobVision is a feature specific to PhobGCC version 2 that provides graphical configuration, calibration, and training tools built into the controller.
 
-![](For_Users/Phobvision_Images/00-mainmenu.jpg?raw=true)
+![](For_Users/Phobvision_Images/00-mainmenu.jpg)
 
 Not every PhobGCC v2 has PhobVision installed. If you're interested, ask your local modder if they can install it.
 
@@ -33,7 +33,7 @@ It doesn't have room to say it, but you can still press Start to skip the measur
 
 However, you are presented with more information than you would get while calibrating using Smashscope, and this may be useful.
 
-![](For_Users/Phobvision_Images/01-calibrate.jpg?raw=true)
+![](For_Users/Phobvision_Images/01-calibrate.jpg)
 
 On the top right, it shows you what step you are at in the procedure.
 During notch adjust, if you haven't measured some of the notches, then it will skip some of the steps.
@@ -68,7 +68,7 @@ The PhobScope tools let you view and record the controller's inputs and outputs 
 
 The Input Viewer shows the current stick positions of the controller, as well as the button and trigger states both before and after remapping and trigger modes are applied.
 
-![](For_Users/Phobvision_Images/02-inputviewer.jpg?raw=true)
+![](For_Users/Phobvision_Images/02-inputviewer.jpg)
 
 The left side shows an octagon representing the standard 100-unit-radius stick gate, with the position of the left stick shown as a large square and the C-stick shown as a small square.
 
@@ -86,7 +86,7 @@ You can see both the coordinates sent to the console and the coordinates as inte
 
 The Stickmap Plots let you record 100 milliseconds of stick motion in 2D and plot it overlaid on various stickmaps relevant to Melee.
 
-![](For_Users/Phobvision_Images/03-stickmapplots.jpg?raw=true)
+![](For_Users/Phobvision_Images/03-stickmapplots.jpg)
 
 This can help you perfect your stick inputs and filter configurations for in-game techniques such as ledgedashing and dashback out of crouch.
 
@@ -115,7 +115,7 @@ Self-explanatory: you only see the stick motion itself.
 
 #### Deadzones
 
-![](For_Users/Phobvision_Images/deadzone1530.png?raw=true)
+![](For_Users/Phobvision_Images/deadzone1530.png)
 
 This shows you the Melee deadzones.
 
@@ -123,33 +123,33 @@ It may be useful for practicing SDI.
 
 #### Wait Attacks
 
-![](For_Users/Phobvision_Images/await1530.png?raw=true)
+![](For_Users/Phobvision_Images/await1530.png)
 
 This shows you the stickmap for A attacks while standing in wait on the ground.
 
 Here's a labered image of this stickmap, although the PhobVision version is made symmetrical:
 
-![](For_Users/Phobvision_Images/await_labeled.png?raw=true)
+![](For_Users/Phobvision_Images/await_labeled.png)
 
 #### Wait Movement
 
-![](For_Users/Phobvision_Images/movewait1530.png?raw=true)
+![](For_Users/Phobvision_Images/movewait1530.png)
 
 This shows you the stickmap for movement while standing in wait on the ground.
 
 Here's a labeled version of it:
 
-![](For_Users/Phobvision_Images/movewait_labeled.png?raw=true)
+![](For_Users/Phobvision_Images/movewait_labeled.png)
 
 #### Crouch
 
-![](For_Users/Phobvision_Images/crouch1530.png?raw=true)
+![](For_Users/Phobvision_Images/crouch1530.png)
 
 This shows you the stickmap for movement while crouching.
 
 Here's a labeled version of it:
 
-![](For_Users/Phobvision_Images/crouch_labeled.png?raw=true)
+![](For_Users/Phobvision_Images/crouch_labeled.png)
 
 This is particularly useful for practicing dashback out of crouch (DBOOC).
 
@@ -164,15 +164,15 @@ On UCF 0.84 and later, those regions are effectively included in the region wher
 
 #### Left and Right Ledge
 
-![](For_Users/Phobvision_Images/ledgeL1530.png?raw=true)
+![](For_Users/Phobvision_Images/ledgeL1530.png)
 
-![](For_Users/Phobvision_Images/ledgeR1530.png?raw=true)
+![](For_Users/Phobvision_Images/ledgeR1530.png)
 
 This shows you the stickmap for options while hanging from ledge (and the horizontal deadzone for your airdodge afterwards).
 
 Here's a labeled version of it, ignoring the deadzones:
 
-![](For_Users/Phobvision_Images/ledge_labeled.png?raw=true)
+![](For_Users/Phobvision_Images/ledge_labeled.png)
 
 This is useful for practicing ledgedashes.
 
@@ -193,7 +193,7 @@ However, if you have the cursor on the Highlight Sample # option, you must manua
 
 ### Snapback
 
-![](For_Users/Phobvision_Images/04-snapback.jpg?raw=true)
+![](For_Users/Phobvision_Images/04-snapback.jpg)
 
 This is only available for stick axes.
 
@@ -205,7 +205,7 @@ As long as you held it on one side long enough before letting go, the percents t
 
 ### Dashback
 
-![](For_Users/Phobvision_Images/05-dashback.jpg?raw=true)
+![](For_Users/Phobvision_Images/05-dashback.jpg)
 
 This is only available for stick axes.
 
@@ -218,7 +218,7 @@ The shorter the time the stick output spends in the range 23-63 inclusive, the l
 
 ### Pivots
 
-![](For_Users/Phobvision_Images/06-pivot.jpg?raw=true)
+![](For_Users/Phobvision_Images/06-pivot.jpg)
 
 This is only available for stick axes.
 
@@ -234,7 +234,7 @@ If the stick output is past the dash threshold for more than 33 ms, you are guar
 
 ### Trigger
 
-![](For_Users/Phobvision_Images/07-trigger.jpg?raw=true)
+![](For_Users/Phobvision_Images/07-trigger.jpg)
 
 This is only available for L or R.
 
@@ -253,7 +253,7 @@ In Melee, an ADT powershield leaves you vulnerable to physical attacks but is oc
 
 The Button Timing Viewer lets you record 200 milliseconds of digital button state and whether each analog axis is past a configurable threshold.
 
-![](For_Users/Phobvision_Images/08-buttontiming_nair.jpg?raw=true)
+![](For_Users/Phobvision_Images/08-buttontiming_nair.jpg)
 
 Press Start to begin a recording, or turn Auto-Repeat On to make it so you don't have to keep pressing Start.
 
@@ -267,13 +267,13 @@ The background lines indicate roughly frame spacing.
 
 You can use this to practice things like frame 1 short hop nair (top image), wavedash timing (below), JC grabs, and more with sub-frame feedback precision.
 
-![](For_Users/Phobvision_Images/09-buttontiming_wavedash.jpg?raw=true)
+![](For_Users/Phobvision_Images/09-buttontiming_wavedash.jpg)
 
 ## Reaction Time Test
 
 The Reaction Time Test is one of the most bare metal reaction time testers you can get, when used on a CRT.
 
-![](For_Users/Phobvision_Images/10-reactiontime.jpg?raw=true)
+![](For_Users/Phobvision_Images/10-reactiontime.jpg)
 
 Press Start and then wait until the white square appears, then press any button or move the sticks.
 You can adjust the stick or analog trigger thresholds if you want.
@@ -292,12 +292,12 @@ Press up or down on the D-Pad to get the diagonal lines to be as smooth as possi
 
 Default configuration on a finicky CRT:
 
-![](For_Users/Phobvision_Images/12-interlace_default.jpg?raw=true)
+![](For_Users/Phobvision_Images/12-interlace_default.jpg)
 
 Good configuration:
 
-![](For_Users/Phobvision_Images/11-interlace_good.jpg?raw=true)
+![](For_Users/Phobvision_Images/11-interlace_good.jpg)
 
 Very bad configuration:
 
-![](For_Users/Phobvision_Images/13-interlace_bad.jpg?raw=true)
+![](For_Users/Phobvision_Images/13-interlace_bad.jpg)

--- a/For_Users/Phobvision_Guide_Latest.md
+++ b/For_Users/Phobvision_Guide_Latest.md
@@ -4,7 +4,7 @@ NOTE: This is for PhobGCC 2 with firmware version 0.29.
 
 PhobVision is a feature specific to PhobGCC version 2 that provides graphical configuration, calibration, and training tools built into the controller.
 
-![](For_Users/Phobvision_Images/00-mainmenu.jpg)
+![](../For_Users/Phobvision_Images/00-mainmenu.jpg)
 
 Not every PhobGCC v2 has PhobVision installed. If you're interested, ask your local modder if they can install it.
 
@@ -28,12 +28,12 @@ Continuing to hold B will cause you to back to the next higher menu level.
 
 # Stick Calibration
 
-When you use PhobVision to calibrate, you can follow the instructions onscreen, which should correspond with the instructions in the [PhobGCC Calibration Guide](For_Users/Phob_Calibration_Guide_Latest.md).
+When you use PhobVision to calibrate, you can follow the instructions onscreen, which should correspond with the instructions in the [PhobGCC Calibration Guide](../For_Users/Phob_Calibration_Guide_Latest.md).
 It doesn't have room to say it, but you can still press Start to skip the measurements and begin notch adjustment on the notches you've measured.
 
 However, you are presented with more information than you would get while calibrating using Smashscope, and this may be useful.
 
-![](For_Users/Phobvision_Images/01-calibrate.jpg)
+![](../For_Users/Phobvision_Images/01-calibrate.jpg)
 
 On the top right, it shows you what step you are at in the procedure.
 During notch adjust, if you haven't measured some of the notches, then it will skip some of the steps.
@@ -68,7 +68,7 @@ The PhobScope tools let you view and record the controller's inputs and outputs 
 
 The Input Viewer shows the current stick positions of the controller, as well as the button and trigger states both before and after remapping and trigger modes are applied.
 
-![](For_Users/Phobvision_Images/02-inputviewer.jpg)
+![](../For_Users/Phobvision_Images/02-inputviewer.jpg)
 
 The left side shows an octagon representing the standard 100-unit-radius stick gate, with the position of the left stick shown as a large square and the C-stick shown as a small square.
 
@@ -86,7 +86,7 @@ You can see both the coordinates sent to the console and the coordinates as inte
 
 The Stickmap Plots let you record 100 milliseconds of stick motion in 2D and plot it overlaid on various stickmaps relevant to Melee.
 
-![](For_Users/Phobvision_Images/03-stickmapplots.jpg)
+![](../For_Users/Phobvision_Images/03-stickmapplots.jpg)
 
 This can help you perfect your stick inputs and filter configurations for in-game techniques such as ledgedashing and dashback out of crouch.
 
@@ -115,7 +115,7 @@ Self-explanatory: you only see the stick motion itself.
 
 #### Deadzones
 
-![](For_Users/Phobvision_Images/deadzone1530.png)
+![](../For_Users/Phobvision_Images/deadzone1530.png)
 
 This shows you the Melee deadzones.
 
@@ -123,33 +123,33 @@ It may be useful for practicing SDI.
 
 #### Wait Attacks
 
-![](For_Users/Phobvision_Images/await1530.png)
+![](../For_Users/Phobvision_Images/await1530.png)
 
 This shows you the stickmap for A attacks while standing in wait on the ground.
 
 Here's a labered image of this stickmap, although the PhobVision version is made symmetrical:
 
-![](For_Users/Phobvision_Images/await_labeled.png)
+![](../For_Users/Phobvision_Images/await_labeled.png)
 
 #### Wait Movement
 
-![](For_Users/Phobvision_Images/movewait1530.png)
+![](../For_Users/Phobvision_Images/movewait1530.png)
 
 This shows you the stickmap for movement while standing in wait on the ground.
 
 Here's a labeled version of it:
 
-![](For_Users/Phobvision_Images/movewait_labeled.png)
+![](../For_Users/Phobvision_Images/movewait_labeled.png)
 
 #### Crouch
 
-![](For_Users/Phobvision_Images/crouch1530.png)
+![](../For_Users/Phobvision_Images/crouch1530.png)
 
 This shows you the stickmap for movement while crouching.
 
 Here's a labeled version of it:
 
-![](For_Users/Phobvision_Images/crouch_labeled.png)
+![](../For_Users/Phobvision_Images/crouch_labeled.png)
 
 This is particularly useful for practicing dashback out of crouch (DBOOC).
 
@@ -164,15 +164,15 @@ On UCF 0.84 and later, those regions are effectively included in the region wher
 
 #### Left and Right Ledge
 
-![](For_Users/Phobvision_Images/ledgeL1530.png)
+![](../For_Users/Phobvision_Images/ledgeL1530.png)
 
-![](For_Users/Phobvision_Images/ledgeR1530.png)
+![](../For_Users/Phobvision_Images/ledgeR1530.png)
 
 This shows you the stickmap for options while hanging from ledge (and the horizontal deadzone for your airdodge afterwards).
 
 Here's a labeled version of it, ignoring the deadzones:
 
-![](For_Users/Phobvision_Images/ledge_labeled.png)
+![](../For_Users/Phobvision_Images/ledge_labeled.png)
 
 This is useful for practicing ledgedashes.
 
@@ -193,7 +193,7 @@ However, if you have the cursor on the Highlight Sample # option, you must manua
 
 ### Snapback
 
-![](For_Users/Phobvision_Images/04-snapback.jpg)
+![](../For_Users/Phobvision_Images/04-snapback.jpg)
 
 This is only available for stick axes.
 
@@ -205,7 +205,7 @@ As long as you held it on one side long enough before letting go, the percents t
 
 ### Dashback
 
-![](For_Users/Phobvision_Images/05-dashback.jpg)
+![](../For_Users/Phobvision_Images/05-dashback.jpg)
 
 This is only available for stick axes.
 
@@ -218,7 +218,7 @@ The shorter the time the stick output spends in the range 23-63 inclusive, the l
 
 ### Pivots
 
-![](For_Users/Phobvision_Images/06-pivot.jpg)
+![](../For_Users/Phobvision_Images/06-pivot.jpg)
 
 This is only available for stick axes.
 
@@ -234,7 +234,7 @@ If the stick output is past the dash threshold for more than 33 ms, you are guar
 
 ### Trigger
 
-![](For_Users/Phobvision_Images/07-trigger.jpg)
+![](../For_Users/Phobvision_Images/07-trigger.jpg)
 
 This is only available for L or R.
 
@@ -253,7 +253,7 @@ In Melee, an ADT powershield leaves you vulnerable to physical attacks but is oc
 
 The Button Timing Viewer lets you record 200 milliseconds of digital button state and whether each analog axis is past a configurable threshold.
 
-![](For_Users/Phobvision_Images/08-buttontiming_nair.jpg)
+![](../For_Users/Phobvision_Images/08-buttontiming_nair.jpg)
 
 Press Start to begin a recording, or turn Auto-Repeat On to make it so you don't have to keep pressing Start.
 
@@ -267,13 +267,13 @@ The background lines indicate roughly frame spacing.
 
 You can use this to practice things like frame 1 short hop nair (top image), wavedash timing (below), JC grabs, and more with sub-frame feedback precision.
 
-![](For_Users/Phobvision_Images/09-buttontiming_wavedash.jpg)
+![](../For_Users/Phobvision_Images/09-buttontiming_wavedash.jpg)
 
 ## Reaction Time Test
 
 The Reaction Time Test is one of the most bare metal reaction time testers you can get, when used on a CRT.
 
-![](For_Users/Phobvision_Images/10-reactiontime.jpg)
+![](../For_Users/Phobvision_Images/10-reactiontime.jpg)
 
 Press Start and then wait until the white square appears, then press any button or move the sticks.
 You can adjust the stick or analog trigger thresholds if you want.
@@ -292,12 +292,12 @@ Press up or down on the D-Pad to get the diagonal lines to be as smooth as possi
 
 Default configuration on a finicky CRT:
 
-![](For_Users/Phobvision_Images/12-interlace_default.jpg)
+![](../For_Users/Phobvision_Images/12-interlace_default.jpg)
 
 Good configuration:
 
-![](For_Users/Phobvision_Images/11-interlace_good.jpg)
+![](../For_Users/Phobvision_Images/11-interlace_good.jpg)
 
 Very bad configuration:
 
-![](For_Users/Phobvision_Images/13-interlace_bad.jpg)
+![](../For_Users/Phobvision_Images/13-interlace_bad.jpg)

--- a/For_Users/Phobvision_Guide_Latest.md
+++ b/For_Users/Phobvision_Guide_Latest.md
@@ -4,7 +4,7 @@ NOTE: This is for PhobGCC 2 with firmware version 0.29.
 
 PhobVision is a feature specific to PhobGCC version 2 that provides graphical configuration, calibration, and training tools built into the controller.
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/00-mainmenu.jpg?raw=true)
+![](For_Users/Phobvision_Images/00-mainmenu.jpg?raw=true)
 
 Not every PhobGCC v2 has PhobVision installed. If you're interested, ask your local modder if they can install it.
 
@@ -28,12 +28,12 @@ Continuing to hold B will cause you to back to the next higher menu level.
 
 # Stick Calibration
 
-When you use PhobVision to calibrate, you can follow the instructions onscreen, which should correspond with the instructions in the [PhobGCC Calibration Guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_Latest.md).
+When you use PhobVision to calibrate, you can follow the instructions onscreen, which should correspond with the instructions in the [PhobGCC Calibration Guide](For_Users/Phob_Calibration_Guide_Latest.md).
 It doesn't have room to say it, but you can still press Start to skip the measurements and begin notch adjustment on the notches you've measured.
 
 However, you are presented with more information than you would get while calibrating using Smashscope, and this may be useful.
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/01-calibrate.jpg?raw=true)
+![](For_Users/Phobvision_Images/01-calibrate.jpg?raw=true)
 
 On the top right, it shows you what step you are at in the procedure.
 During notch adjust, if you haven't measured some of the notches, then it will skip some of the steps.
@@ -68,7 +68,7 @@ The PhobScope tools let you view and record the controller's inputs and outputs 
 
 The Input Viewer shows the current stick positions of the controller, as well as the button and trigger states both before and after remapping and trigger modes are applied.
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/02-inputviewer.jpg?raw=true)
+![](For_Users/Phobvision_Images/02-inputviewer.jpg?raw=true)
 
 The left side shows an octagon representing the standard 100-unit-radius stick gate, with the position of the left stick shown as a large square and the C-stick shown as a small square.
 
@@ -86,7 +86,7 @@ You can see both the coordinates sent to the console and the coordinates as inte
 
 The Stickmap Plots let you record 100 milliseconds of stick motion in 2D and plot it overlaid on various stickmaps relevant to Melee.
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/03-stickmapplots.jpg?raw=true)
+![](For_Users/Phobvision_Images/03-stickmapplots.jpg?raw=true)
 
 This can help you perfect your stick inputs and filter configurations for in-game techniques such as ledgedashing and dashback out of crouch.
 
@@ -115,7 +115,7 @@ Self-explanatory: you only see the stick motion itself.
 
 #### Deadzones
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/deadzone1530.png?raw=true)
+![](For_Users/Phobvision_Images/deadzone1530.png?raw=true)
 
 This shows you the Melee deadzones.
 
@@ -123,33 +123,33 @@ It may be useful for practicing SDI.
 
 #### Wait Attacks
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/await1530.png?raw=true)
+![](For_Users/Phobvision_Images/await1530.png?raw=true)
 
 This shows you the stickmap for A attacks while standing in wait on the ground.
 
 Here's a labered image of this stickmap, although the PhobVision version is made symmetrical:
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/await_labeled.png?raw=true)
+![](For_Users/Phobvision_Images/await_labeled.png?raw=true)
 
 #### Wait Movement
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/movewait1530.png?raw=true)
+![](For_Users/Phobvision_Images/movewait1530.png?raw=true)
 
 This shows you the stickmap for movement while standing in wait on the ground.
 
 Here's a labeled version of it:
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/movewait_labeled.png?raw=true)
+![](For_Users/Phobvision_Images/movewait_labeled.png?raw=true)
 
 #### Crouch
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/crouch1530.png?raw=true)
+![](For_Users/Phobvision_Images/crouch1530.png?raw=true)
 
 This shows you the stickmap for movement while crouching.
 
 Here's a labeled version of it:
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/crouch_labeled.png?raw=true)
+![](For_Users/Phobvision_Images/crouch_labeled.png?raw=true)
 
 This is particularly useful for practicing dashback out of crouch (DBOOC).
 
@@ -164,15 +164,15 @@ On UCF 0.84 and later, those regions are effectively included in the region wher
 
 #### Left and Right Ledge
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/ledgeL1530.png?raw=true)
+![](For_Users/Phobvision_Images/ledgeL1530.png?raw=true)
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/ledgeR1530.png?raw=true)
+![](For_Users/Phobvision_Images/ledgeR1530.png?raw=true)
 
 This shows you the stickmap for options while hanging from ledge (and the horizontal deadzone for your airdodge afterwards).
 
 Here's a labeled version of it, ignoring the deadzones:
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/ledge_labeled.png?raw=true)
+![](For_Users/Phobvision_Images/ledge_labeled.png?raw=true)
 
 This is useful for practicing ledgedashes.
 
@@ -193,7 +193,7 @@ However, if you have the cursor on the Highlight Sample # option, you must manua
 
 ### Snapback
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/04-snapback.jpg?raw=true)
+![](For_Users/Phobvision_Images/04-snapback.jpg?raw=true)
 
 This is only available for stick axes.
 
@@ -205,7 +205,7 @@ As long as you held it on one side long enough before letting go, the percents t
 
 ### Dashback
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/05-dashback.jpg?raw=true)
+![](For_Users/Phobvision_Images/05-dashback.jpg?raw=true)
 
 This is only available for stick axes.
 
@@ -218,7 +218,7 @@ The shorter the time the stick output spends in the range 23-63 inclusive, the l
 
 ### Pivots
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/06-pivot.jpg?raw=true)
+![](For_Users/Phobvision_Images/06-pivot.jpg?raw=true)
 
 This is only available for stick axes.
 
@@ -234,7 +234,7 @@ If the stick output is past the dash threshold for more than 33 ms, you are guar
 
 ### Trigger
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/07-trigger.jpg?raw=true)
+![](For_Users/Phobvision_Images/07-trigger.jpg?raw=true)
 
 This is only available for L or R.
 
@@ -253,7 +253,7 @@ In Melee, an ADT powershield leaves you vulnerable to physical attacks but is oc
 
 The Button Timing Viewer lets you record 200 milliseconds of digital button state and whether each analog axis is past a configurable threshold.
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/08-buttontiming_nair.jpg?raw=true)
+![](For_Users/Phobvision_Images/08-buttontiming_nair.jpg?raw=true)
 
 Press Start to begin a recording, or turn Auto-Repeat On to make it so you don't have to keep pressing Start.
 
@@ -267,13 +267,13 @@ The background lines indicate roughly frame spacing.
 
 You can use this to practice things like frame 1 short hop nair (top image), wavedash timing (below), JC grabs, and more with sub-frame feedback precision.
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/09-buttontiming_wavedash.jpg?raw=true)
+![](For_Users/Phobvision_Images/09-buttontiming_wavedash.jpg?raw=true)
 
 ## Reaction Time Test
 
 The Reaction Time Test is one of the most bare metal reaction time testers you can get, when used on a CRT.
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/10-reactiontime.jpg?raw=true)
+![](For_Users/Phobvision_Images/10-reactiontime.jpg?raw=true)
 
 Press Start and then wait until the white square appears, then press any button or move the sticks.
 You can adjust the stick or analog trigger thresholds if you want.
@@ -292,12 +292,12 @@ Press up or down on the D-Pad to get the diagonal lines to be as smooth as possi
 
 Default configuration on a finicky CRT:
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/12-interlace_default.jpg?raw=true)
+![](For_Users/Phobvision_Images/12-interlace_default.jpg?raw=true)
 
 Good configuration:
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/11-interlace_good.jpg?raw=true)
+![](For_Users/Phobvision_Images/11-interlace_good.jpg?raw=true)
 
 Very bad configuration:
 
-![](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Images/13-interlace_bad.jpg?raw=true)
+![](For_Users/Phobvision_Images/13-interlace_bad.jpg?raw=true)

--- a/General_Info/Hall_Effect_Sensors.md
+++ b/General_Info/Hall_Effect_Sensors.md
@@ -2,13 +2,13 @@ Hall effect sensors work by measuring how hard moving charges get pushed/pulled 
 
 We can use this effect by attaching a magnet to the stickbox peg in the correct orientation, and placing a sensor underneath it. When the magnetic field is perpendicular to the sensor's direction of sensitivity, no field is detected and the sensor will output ~1V:
 
-![Magnet level](https://github.com/PhobGCC/PhobGCC-doc/blob/main/General_Info/Hall_Effect_Sensors_Images/level_magnet.png?raw=true)
+![Magnet level](General_Info/Hall_Effect_Sensors_Images/level_magnet.png?raw=true)
 
 When the field tilts one way, the output voltage will decrease:
-![Magnet tilted left](https://github.com/PhobGCC/PhobGCC-doc/blob/main/General_Info/Hall_Effect_Sensors_Images/left_magnet.png?raw=true)
+![Magnet tilted left](General_Info/Hall_Effect_Sensors_Images/left_magnet.png?raw=true)
 
 When the field tilts the other way, the output voltage will increase:
-![Magnet tilted right](https://github.com/PhobGCC/PhobGCC-doc/blob/main/General_Info/Hall_Effect_Sensors_Images/right_magnet.png?raw=true)
+![Magnet tilted right](General_Info/Hall_Effect_Sensors_Images/right_magnet.png?raw=true)
 
 When we glue the magnets on they are not perfectly aligned, so we won't get this perfect behavior, but this is roughly what happens. The microcontroller reads these voltages the same way it does from a potentiometer, but we will need to scale possibly linearize the signal before it can be used to control the stick. The primary advantage is that the Hall effect sensor will not wear out like a potentiometer will. As long as the magnet stays in place it will continue working.
 

--- a/General_Info/Hall_Effect_Sensors.md
+++ b/General_Info/Hall_Effect_Sensors.md
@@ -2,13 +2,13 @@ Hall effect sensors work by measuring how hard moving charges get pushed/pulled 
 
 We can use this effect by attaching a magnet to the stickbox peg in the correct orientation, and placing a sensor underneath it. When the magnetic field is perpendicular to the sensor's direction of sensitivity, no field is detected and the sensor will output ~1V:
 
-![Magnet level](General_Info/Hall_Effect_Sensors_Images/level_magnet.png)
+![Magnet level](../General_Info/Hall_Effect_Sensors_Images/level_magnet.png)
 
 When the field tilts one way, the output voltage will decrease:
-![Magnet tilted left](General_Info/Hall_Effect_Sensors_Images/left_magnet.png)
+![Magnet tilted left](../General_Info/Hall_Effect_Sensors_Images/left_magnet.png)
 
 When the field tilts the other way, the output voltage will increase:
-![Magnet tilted right](General_Info/Hall_Effect_Sensors_Images/right_magnet.png)
+![Magnet tilted right](../General_Info/Hall_Effect_Sensors_Images/right_magnet.png)
 
 When we glue the magnets on they are not perfectly aligned, so we won't get this perfect behavior, but this is roughly what happens. The microcontroller reads these voltages the same way it does from a potentiometer, but we will need to scale possibly linearize the signal before it can be used to control the stick. The primary advantage is that the Hall effect sensor will not wear out like a potentiometer will. As long as the magnet stays in place it will continue working.
 

--- a/General_Info/Hall_Effect_Sensors.md
+++ b/General_Info/Hall_Effect_Sensors.md
@@ -2,13 +2,13 @@ Hall effect sensors work by measuring how hard moving charges get pushed/pulled 
 
 We can use this effect by attaching a magnet to the stickbox peg in the correct orientation, and placing a sensor underneath it. When the magnetic field is perpendicular to the sensor's direction of sensitivity, no field is detected and the sensor will output ~1V:
 
-![Magnet level](General_Info/Hall_Effect_Sensors_Images/level_magnet.png?raw=true)
+![Magnet level](General_Info/Hall_Effect_Sensors_Images/level_magnet.png)
 
 When the field tilts one way, the output voltage will decrease:
-![Magnet tilted left](General_Info/Hall_Effect_Sensors_Images/left_magnet.png?raw=true)
+![Magnet tilted left](General_Info/Hall_Effect_Sensors_Images/left_magnet.png)
 
 When the field tilts the other way, the output voltage will increase:
-![Magnet tilted right](General_Info/Hall_Effect_Sensors_Images/right_magnet.png?raw=true)
+![Magnet tilted right](General_Info/Hall_Effect_Sensors_Images/right_magnet.png)
 
 When we glue the magnets on they are not perfectly aligned, so we won't get this perfect behavior, but this is roughly what happens. The microcontroller reads these voltages the same way it does from a potentiometer, but we will need to scale possibly linearize the signal before it can be used to control the stick. The primary advantage is that the Hall effect sensor will not wear out like a potentiometer will. As long as the magnet stays in place it will continue working.
 

--- a/General_Info/Notch_Remapping.md
+++ b/General_Info/Notch_Remapping.md
@@ -1,6 +1,6 @@
 Notch remapping is done by dividing stick space into triangular shaped regions, then applying an affine transformation(https://brilliant.org/wiki/affine-transformations/) to each triangular shaped region to match up the corners of each region with the desired notches:
 
-![Remap](General_Info/Notch_Remapping_Images/gate_warp.png?raw=true)
+![Remap](General_Info/Notch_Remapping_Images/gate_warp.png)
 
 Region A gets transformed into region A', B into B', etc. This illustration is exaggerated to show how things work, the actual notch positions are not this far off. In this way things can be stretched so that when the stick is in the physical notch, it gives the correct coordinates.
 

--- a/General_Info/Notch_Remapping.md
+++ b/General_Info/Notch_Remapping.md
@@ -1,6 +1,6 @@
 Notch remapping is done by dividing stick space into triangular shaped regions, then applying an affine transformation(https://brilliant.org/wiki/affine-transformations/) to each triangular shaped region to match up the corners of each region with the desired notches:
 
-![Remap](https://github.com/PhobGCC/PhobGCC-doc/blob/main/General_Info/Notch_Remapping_Images/gate_warp.png?raw=true)
+![Remap](General_Info/Notch_Remapping_Images/gate_warp.png?raw=true)
 
 Region A gets transformed into region A', B into B', etc. This illustration is exaggerated to show how things work, the actual notch positions are not this far off. In this way things can be stretched so that when the stick is in the physical notch, it gives the correct coordinates.
 

--- a/General_Info/Notch_Remapping.md
+++ b/General_Info/Notch_Remapping.md
@@ -1,6 +1,6 @@
 Notch remapping is done by dividing stick space into triangular shaped regions, then applying an affine transformation(https://brilliant.org/wiki/affine-transformations/) to each triangular shaped region to match up the corners of each region with the desired notches:
 
-![Remap](General_Info/Notch_Remapping_Images/gate_warp.png)
+![Remap](../General_Info/Notch_Remapping_Images/gate_warp.png)
 
 Region A gets transformed into region A', B into B', etc. This illustration is exaggerated to show how things work, the actual notch positions are not this far off. In this way things can be stretched so that when the stick is in the physical notch, it gives the correct coordinates.
 

--- a/General_Info/Signal_Linearization.md
+++ b/General_Info/Signal_Linearization.md
@@ -2,11 +2,11 @@
 
 Imagine we move the stick into the 8 different gate notches and record the x-position at each location. We would expect to get the values -1.0,-0.71,0,0.71, and 1.0, depending on which notch we were in. But with the hall effect sensors we might get something else, we might get -0.63,-0.52,0.0,0.29, and 0.33 for example.
 
-![Octagonal Gate Measured Positions](General_Info/Signal_Linearization_Images/octagonal_gate.png?raw=true)
+![Octagonal Gate Measured Positions](General_Info/Signal_Linearization_Images/octagonal_gate.png)
 
  But since we know what the values should be, we can find an equation which transforms the values from the hall sensor into the values we want:
 
-![Linearization Function](General_Info/Signal_Linearization_Images/linearization_function.png?raw=true)
+![Linearization Function](General_Info/Signal_Linearization_Images/linearization_function.png)
 
 The simplest function that appears to do a reasonable job of fitting the hall effect sensor data has been a 3rd order polynomial of the form Ax^3 + Bx^2 + Cx + D. Using these x-values measured at the gate notches we can find the coefficients A,B,C,D through regression analysis (usually ordinary least squares), then we just substitute the value we got from the sensor into x, and we get the linearized output.
 

--- a/General_Info/Signal_Linearization.md
+++ b/General_Info/Signal_Linearization.md
@@ -2,11 +2,11 @@
 
 Imagine we move the stick into the 8 different gate notches and record the x-position at each location. We would expect to get the values -1.0,-0.71,0,0.71, and 1.0, depending on which notch we were in. But with the hall effect sensors we might get something else, we might get -0.63,-0.52,0.0,0.29, and 0.33 for example.
 
-![Octagonal Gate Measured Positions](https://github.com/PhobGCC/PhobGCC-doc/blob/main/General_Info/Signal_Linearization_Images/octagonal_gate.png?raw=true)
+![Octagonal Gate Measured Positions](General_Info/Signal_Linearization_Images/octagonal_gate.png?raw=true)
 
  But since we know what the values should be, we can find an equation which transforms the values from the hall sensor into the values we want:
 
-![Linearization Function](https://github.com/PhobGCC/PhobGCC-doc/blob/main/General_Info/Signal_Linearization_Images/linearization_function.png?raw=true)
+![Linearization Function](General_Info/Signal_Linearization_Images/linearization_function.png?raw=true)
 
 The simplest function that appears to do a reasonable job of fitting the hall effect sensor data has been a 3rd order polynomial of the form Ax^3 + Bx^2 + Cx + D. Using these x-values measured at the gate notches we can find the coefficients A,B,C,D through regression analysis (usually ordinary least squares), then we just substitute the value we got from the sensor into x, and we get the linearized output.
 

--- a/General_Info/Signal_Linearization.md
+++ b/General_Info/Signal_Linearization.md
@@ -2,11 +2,11 @@
 
 Imagine we move the stick into the 8 different gate notches and record the x-position at each location. We would expect to get the values -1.0,-0.71,0,0.71, and 1.0, depending on which notch we were in. But with the hall effect sensors we might get something else, we might get -0.63,-0.52,0.0,0.29, and 0.33 for example.
 
-![Octagonal Gate Measured Positions](General_Info/Signal_Linearization_Images/octagonal_gate.png)
+![Octagonal Gate Measured Positions](../General_Info/Signal_Linearization_Images/octagonal_gate.png)
 
  But since we know what the values should be, we can find an equation which transforms the values from the hall sensor into the values we want:
 
-![Linearization Function](General_Info/Signal_Linearization_Images/linearization_function.png)
+![Linearization Function](../General_Info/Signal_Linearization_Images/linearization_function.png)
 
 The simplest function that appears to do a reasonable job of fitting the hall effect sensor data has been a 3rd order polynomial of the form Ax^3 + Bx^2 + Cx + D. Using these x-values measured at the gate notches we can find the coefficients A,B,C,D through regression analysis (usually ordinary least squares), then we just substitute the value we got from the sensor into x, and we get the linearized output.
 

--- a/LEGACY.md
+++ b/LEGACY.md
@@ -4,15 +4,15 @@ This document is to keep track of old documentation that is no longer applicable
 
 ## Controller Configuration
 
-* [For Version 0.28](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.28.md)
-* [For Version 0.27](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.27.md)
-* [For Version 0.26](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.26.md)
-* [For Version 0.25](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.25.md)
-* [For Version 0.24](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.24.md)
-* [For Version 0.23](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.23.md)
-* [For Version 0.22](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.22.md)
-* [For Version 0.21](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.21.md)
-* [For Version 0.20](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_v0.20.md)
+* [For Version 0.28](For_Users/Phob_Calibration_Guide_v0.28.md)
+* [For Version 0.27](For_Users/Phob_Calibration_Guide_v0.27.md)
+* [For Version 0.26](For_Users/Phob_Calibration_Guide_v0.26.md)
+* [For Version 0.25](For_Users/Phob_Calibration_Guide_v0.25.md)
+* [For Version 0.24](For_Users/Phob_Calibration_Guide_v0.24.md)
+* [For Version 0.23](For_Users/Phob_Calibration_Guide_v0.23.md)
+* [For Version 0.22](For_Users/Phob_Calibration_Guide_v0.22.md)
+* [For Version 0.21](For_Users/Phob_Calibration_Guide_v0.21.md)
+* [For Version 0.20](For_Users/Phob_Calibration_Guide_v0.20.md)
 * [For Version 0.18-0.19](https://docs.google.com/document/d/1tICHkeWHWOi87ebddIgM1hSR2AaJqE-wSA17Wzhi0u0/edit?usp=sharing)
 * [For Version 0.16-0.17](https://docs.google.com/document/d/11UUmMImXMPYMJ9wzESQMvJrMNCCeWAxyutiNewseW9k/edit?usp=sharing)
 

--- a/README.md
+++ b/README.md
@@ -9,55 +9,55 @@ This comes together to make a high-performance, customizable, long-lasting contr
 
 Come chat with us on the [PhobGCC Discord](https://discord.gg/eNJ7xWMvxf)!
 
-![PhobGCC](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/BuildPics_2.0.1/Phob2_Front.jpg?raw=true)
+![PhobGCC](For_Makers/BuildPics_2.0.1/Phob2_Front.jpg?raw=true)
 
 ## For Buyers and Users
 
-[PhobGCC Buying Guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Buying_Guide.md)
+[PhobGCC Buying Guide](For_Users/Phob_Buying_Guide.md)
 
-[PhobGCC Calibration/Configuration Guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Calibration_Guide_Latest.md)
+[PhobGCC Calibration/Configuration Guide](For_Users/Phob_Calibration_Guide_Latest.md)
 
-[PhobVision and PhobScope User Guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phobvision_Guide_Latest.md)
+[PhobVision and PhobScope User Guide](For_Users/Phobvision_Guide_Latest.md)
 
-[PhobGCC v2.0 Firmware Update Guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob2_Programming_Guide.md)
+[PhobGCC v2.0 Firmware Update Guide](For_Users/Phob2_Programming_Guide.md)
 
-[PhobGCC v1.X Firmware Update Guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Programming_Guide.md)
+[PhobGCC v1.X Firmware Update Guide](For_Users/Phob_Programming_Guide.md)
 
-[User guides for Extras](https://github.com/PhobGCC/PhobGCC-doc/tree/main/For_Users/Extras_Guides)
+[User guides for Extras](For_Users/Extras_Guides)
 
 ## For Makers and Sellers
 
-[PhobGCC v2.0.5 Parts Ordering Guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob2_Ordering_Guide.md)
+[PhobGCC v2.0.5 Parts Ordering Guide](For_Makers/Phob2_Ordering_Guide.md)
 
-[Build Guide for PhobGCC 2.0](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Build_Guide_2.0.md)
+[Build Guide for PhobGCC 2.0](For_Makers/Build_Guide_2.0.md)
 
-[Board Fixes for PhobGCC design flaws](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Board_Fixes.md)
+[Board Fixes for PhobGCC design flaws](For_Makers/Board_Fixes.md)
 
-[PhobGCC v1.2.3 Parts Ordering Guide](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Phob_Ordering_Guide.md)
+[PhobGCC v1.2.3 Parts Ordering Guide](For_Makers/Phob_Ordering_Guide.md)
 
 [Build Video for PhobGCC 1.2](https://youtu.be/0QmgswFa1cA)
 
-[Build Guide for PhobGCC 1.2](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Build_Guide_1.2.md)
+[Build Guide for PhobGCC 1.2](For_Makers/Build_Guide_1.2.md)
 
-[Board Debugging for PhobGCC 1.2](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Makers/Board_Level_Debugging_1.2.md) (read before plugging in the first time!)
+[Board Debugging for PhobGCC 1.2](For_Makers/Board_Level_Debugging_1.2.md) (read before plugging in the first time!)
 
-[Guide to Programming PhobGCC v2.0](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob2_Programming_Guide.md)
+[Guide to Programming PhobGCC v2.0](For_Users/Phob2_Programming_Guide.md)
 
-[Guide to Programming PhobGCC v1.X](https://github.com/PhobGCC/PhobGCC-doc/blob/main/For_Users/Phob_Programming_Guide.md)
+[Guide to Programming PhobGCC v1.X](For_Users/Phob_Programming_Guide.md)
 
 ## General Info
 
-[Hall Effect Sensor Explanation](https://github.com/PhobGCC/PhobGCC-doc/blob/main/General_Info/Hall_Effect_Sensors.md)
+[Hall Effect Sensor Explanation](General_Info/Hall_Effect_Sensors.md)
 
-[Signal Linearization](https://github.com/PhobGCC/PhobGCC-doc/blob/main/General_Info/Signal_Linearization.md)
+[Signal Linearization](General_Info/Signal_Linearization.md)
 
-[Snapback Filter](https://github.com/PhobGCC/PhobGCC-doc/blob/main/General_Info/Snapback_Filter.md)
+[Snapback Filter](General_Info/Snapback_Filter.md)
 
-[Notch Remapping](https://github.com/PhobGCC/PhobGCC-doc/blob/main/General_Info/Notch_Remapping.md)
+[Notch Remapping](General_Info/Notch_Remapping.md)
 
 ## Legacy Info
 
-[Legacy Documentation Page](https://github.com/PhobGCC/PhobGCC-doc/blob/main/LEGACY.md)
+[Legacy Documentation Page](LEGACY.md)
 
 ![Creative Commons License](https://i.creativecommons.org/l/by-sa/4.0/88x31.png)
 This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This comes together to make a high-performance, customizable, long-lasting contr
 
 Come chat with us on the [PhobGCC Discord](https://discord.gg/eNJ7xWMvxf)!
 
-![PhobGCC](For_Makers/BuildPics_2.0.1/Phob2_Front.jpg?raw=true)
+![PhobGCC](For_Makers/BuildPics_2.0.1/Phob2_Front.jpg)
 
 ## For Buyers and Users
 


### PR DESCRIPTION
The documentation can now easily stand on its own, without always pointing to GitHub.
Preserves forks in the event of a link/file name changes in the original “upstream” repo (PhobGCC/PhobGCC-doc).