### PR TITLE
Update Phob2_Ordering_Guide.md

### DIFF
--- a/For_Makers/Phob2_Ordering_Guide.md
+++ b/For_Makers/Phob2_Ordering_Guide.md
@@ -116,7 +116,7 @@ The remaining parts can be purchased from distributors as listed below.
   * 6-pin Ribbon Cable from [Tbox](https://www.etsy.com/listing/1479077608/phob-202-6-pin-c-stick-ribbon-cables) (NA)
 * Optional Mouse Buttons for ABXYLR: you can use mouse buttons for any number from 0 to 6 of the buttons. Generally the high actuation force buttons are preferred.
   * [Low Actuation Force Buttons](https://www.digikey.com/short/q4r0jh3j)
-  * [High Actuation Force Buttons](https://www.digikey.com/short/dcddr0jr)
+  * [High Actuation Force Buttons](https://www.digikey.com/en/products/detail/omron-electronics-inc-emc-div/D2LS-11/5031939)
   * [Teflon Tape For Support](https://www.mcmaster.com/76475A51/) This is necessary for mouseclick face buttons, but there are alternatives.
 * Optional Discrete Buttons for D-Pad:
   * [Tactile SMD Buttons](https://www.digikey.com/short/7pw830cj)


### PR DESCRIPTION
Fix broken Digikey link for D2LS-11 (high force actuation switches)

Uses a full link instead of a short link, as I couldn't see a reason for the short link.